### PR TITLE
Add Dwight Pi node mapping and avatar fallback

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -56,6 +56,7 @@ NODE_LOCATIONS = {
     # Raspberry Pi nodes (at home)
     'michael-pi': {**HOME_LOCATION, 'location': f"{HOME_LOCATION['city']} (Home)", 'provider': 'raspberry-pi'},
     'jim-pi': {**HOME_LOCATION, 'location': f"{HOME_LOCATION['city']} (Home)", 'provider': 'raspberry-pi'},
+    'dwight-pi': {**HOME_LOCATION, 'location': f"{HOME_LOCATION['city']} (Home)", 'provider': 'raspberry-pi'},
     
     # Oracle Cloud nodes (San Jose datacenter)
     'angela-amd2': {**CLOUD_LOCATIONS['oracle'], 'provider': 'oracle'},

--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -37,15 +37,17 @@ const getFallbackAvatar = (nodeName: string): string => {
   const characterNames: Record<string, string> = {
     'michael': 'Michael+Scott',
     'jim': 'Jim+Halpert',
+    'dwight': 'Dwight+Schrute',
     'angela': 'Angela+Martin',
     'stanley': 'Stanley+Hudson',
     'phyllis': 'Phyllis+Vance',
     'toby': 'Toby+Flenderson',
   };
-  
+
   const characterColors: Record<string, string> = {
     'michael': '667eea',
     'jim': '4285F4',
+    'dwight': 'FFC107',
     'angela': '9c27b0',
     'stanley': 'ff9800',
     'phyllis': '4caf50',


### PR DESCRIPTION
## Summary
- map Dwight's Raspberry Pi node to the home location so it receives coordinates from the agent
- provide a Dwight-specific fallback avatar configuration for the frontend markers

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68fc134c9690833290ee5370281df575