### PR TITLE
Add workflow to build and publish Docker images

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,71 @@
+name: Build and Publish Container Images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
+  VERSION: ${{ vars.VERSION != '' && vars.VERSION || 'latest' }}
+  PLATFORMS: ${{ vars.PLATFORMS != '' && vars.PLATFORMS || 'linux/amd64,linux/arm64' }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: agent
+            context: ./agent
+            image: homelab-map-agent
+          - name: aggregator
+            context: ./aggregator
+            image: homelab-map-aggregator
+          - name: frontend
+            context: ./frontend
+            image: homelab-map-frontend
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Determine registry host
+        id: registry
+        run: |
+          registry="${REGISTRY}"
+          if [[ "$registry" == */* ]]; then
+            host="${registry%%/*}"
+          else
+            host="$registry"
+          fi
+          echo "host=$host" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.registry.outputs.host }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.VERSION }}
+            ${{ env.REGISTRY }}/${{ matrix.image }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and pushes the agent, aggregator, and frontend images on merges to main
- support configurable registry, version, and platform defaults via repository variables, matching the local build script behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc1603ed5483328249e90dba114f8f