### PR TITLE
feat: automate semver releases

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,19 +1,34 @@
 name: Build and Publish Container Images
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      version:
+        description: "SemVer tag to apply to all images"
+        required: true
+        type: string
+    secrets:
+      REGISTRY_USERNAME:
+        required: true
+      REGISTRY_PASSWORD:
+        required: true
   workflow_dispatch:
+    inputs:
+      version:
+        description: "SemVer tag to apply to all images"
+        required: true
+        type: string
+        default: latest
 
 env:
   REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
-  VERSION: ${{ vars.VERSION != '' && vars.VERSION || 'latest' }}
   PLATFORMS: ${{ vars.PLATFORMS != '' && vars.PLATFORMS || 'linux/amd64,linux/arm64' }}
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "SemVer bump to apply when run manually"
+        default: patch
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+env:
+  REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
+  APP_MANIFESTS_REPO: ${{ vars.APP_MANIFESTS_REPO != '' && vars.APP_MANIFESTS_REPO || '' }}
+  APP_MANIFESTS_BRANCH: ${{ vars.APP_MANIFESTS_BRANCH != '' && vars.APP_MANIFESTS_BRANCH || 'main' }}
+  APP_MANIFESTS_SERVICES: ${{ vars.APP_MANIFESTS_SERVICES != '' && vars.APP_MANIFESTS_SERVICES || 'agent,aggregator,frontend' }}
+
+jobs:
+  prepare-release:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      version: ${{ steps.bump_version.outputs.version }}
+    steps:
+      - name: Check out merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Determine version bump
+        id: bump_level
+        uses: actions/github-script@v7
+        with:
+          manual-bump: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump || '' }}
+          result-encoding: string
+          script: |
+            const manual = core.getInput('manual-bump');
+            if (manual) {
+              core.info(`Using manual bump: ${manual}`);
+              return manual;
+            }
+            const labels = (context.payload.pull_request?.labels || []).map(label => label.name.toLowerCase());
+            const has = (candidates) => labels.some(label => candidates.includes(label));
+            if (has(['major release', 'major', 'breaking', 'release:major', 'semver:major'])) {
+              return 'major';
+            }
+            if (has(['feat', 'feature', 'enhancement', 'minor', 'release:minor', 'semver:minor'])) {
+              return 'minor';
+            }
+            if (has(['fix', 'patch', 'bug', 'bugfix', 'hotfix', 'release:patch', 'semver:patch'])) {
+              return 'patch';
+            }
+            core.info('No bump label found; defaulting to patch');
+            return 'patch';
+
+      - name: Determine current version
+        id: current_tag
+        run: |
+          set -euo pipefail
+          latest="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+          if [[ -z "$latest" ]]; then
+            base="0.0.0"
+          else
+            base="${latest#v}"
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate next version
+        id: bump_version
+        run: |
+          set -euo pipefail
+          current="${{ steps.current_tag.outputs.base }}"
+          bump="${{ steps.bump_level.outputs.result }}"
+          IFS='.' read -r major minor patch <<<"${current:-0.0.0}"
+          major="${major:-0}"
+          minor="${minor:-0}"
+          patch="${patch:-0}"
+          case "$bump" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            *)
+              patch=$((patch + 1))
+              ;;
+          esac
+          version="v${major}.${minor}.${patch}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ steps.bump_version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION" ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          git push origin "$VERSION"
+
+  build-and-push:
+    needs: prepare-release
+    if: needs.prepare-release.outputs.version != ''
+    uses: ./.github/workflows/build-and-publish.yml
+    with:
+      version: ${{ needs.prepare-release.outputs.version }}
+    secrets: inherit
+
+  update-app-manifests:
+    needs:
+      - prepare-release
+      - build-and-push
+    if: vars.APP_MANIFESTS_REPO != '' && needs.prepare-release.outputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      VERSION: ${{ needs.prepare-release.outputs.version }}
+      REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
+      APP_MANIFESTS_REPO: ${{ vars.APP_MANIFESTS_REPO != '' && vars.APP_MANIFESTS_REPO || '' }}
+      APP_MANIFESTS_BRANCH: ${{ vars.APP_MANIFESTS_BRANCH != '' && vars.APP_MANIFESTS_BRANCH || 'main' }}
+      APP_MANIFESTS_SERVICES: ${{ vars.APP_MANIFESTS_SERVICES != '' && vars.APP_MANIFESTS_SERVICES || 'agent,aggregator,frontend' }}
+    steps:
+      - name: Check out homelab-map
+        uses: actions/checkout@v4
+
+      - name: Check out app manifests
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.APP_MANIFESTS_REPO }}
+          token: ${{ secrets.APP_MANIFESTS_TOKEN }}
+          ref: ${{ env.APP_MANIFESTS_BRANCH }}
+          path: app-manifests
+
+      - name: Update image tags
+        run: |
+          service_args=$(printf ' --services %s' $(echo "${APP_MANIFESTS_SERVICES}" | tr ',' ' '))
+          python3 scripts/update_app_manifests.py \
+            --repo-path app-manifests \
+            --version "${VERSION}" \
+            --registry "${REGISTRY}" \
+            ${service_args}
+
+      - name: Open PR in app-manifests
+        uses: peter-evans/create-pull-request@v6
+        with:
+          path: app-manifests
+          token: ${{ secrets.APP_MANIFESTS_TOKEN }}
+          commit-message: "chore: update homelab-map images to ${{ env.VERSION }}"
+          branch: automation/homelab-map-${{ env.VERSION }}
+          base: ${{ env.APP_MANIFESTS_BRANCH }}
+          title: "chore: homelab-map ${{ env.VERSION }}"
+          body: |
+            Update homelab-map image tags to `${{ env.VERSION }}`.
+          labels: |
+            automated
+            homelab-map
+          delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ on:
 
 env:
   REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
-  APP_MANIFESTS_REPO: ${{ vars.APP_MANIFESTS_REPO != '' && vars.APP_MANIFESTS_REPO || '' }}
-  APP_MANIFESTS_BRANCH: ${{ vars.APP_MANIFESTS_BRANCH != '' && vars.APP_MANIFESTS_BRANCH || 'main' }}
-  APP_MANIFESTS_SERVICES: ${{ vars.APP_MANIFESTS_SERVICES != '' && vars.APP_MANIFESTS_SERVICES || 'agent,aggregator,frontend' }}
+  HOMELAB_DEPLOYMENTS_REPO: ${{ vars.HOMELAB_DEPLOYMENTS_REPO != '' && vars.HOMELAB_DEPLOYMENTS_REPO || '' }}
+  HOMELAB_DEPLOYMENTS_BRANCH: ${{ vars.HOMELAB_DEPLOYMENTS_BRANCH != '' && vars.HOMELAB_DEPLOYMENTS_BRANCH || 'main' }}
+  HOMELAB_DEPLOYMENTS_SERVICES: ${{ vars.HOMELAB_DEPLOYMENTS_SERVICES != '' && vars.HOMELAB_DEPLOYMENTS_SERVICES || 'agent,aggregator,frontend' }}
 
 jobs:
   prepare-release:
@@ -124,11 +124,11 @@ jobs:
       version: ${{ needs.prepare-release.outputs.version }}
     secrets: inherit
 
-  update-app-manifests:
+  update-homelab-deployments:
     needs:
       - prepare-release
       - build-and-push
-    if: vars.APP_MANIFESTS_REPO != '' && needs.prepare-release.outputs.version != ''
+    if: vars.HOMELAB_DEPLOYMENTS_REPO != '' && needs.prepare-release.outputs.version != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,38 +136,38 @@ jobs:
     env:
       VERSION: ${{ needs.prepare-release.outputs.version }}
       REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
-      APP_MANIFESTS_REPO: ${{ vars.APP_MANIFESTS_REPO != '' && vars.APP_MANIFESTS_REPO || '' }}
-      APP_MANIFESTS_BRANCH: ${{ vars.APP_MANIFESTS_BRANCH != '' && vars.APP_MANIFESTS_BRANCH || 'main' }}
-      APP_MANIFESTS_SERVICES: ${{ vars.APP_MANIFESTS_SERVICES != '' && vars.APP_MANIFESTS_SERVICES || 'agent,aggregator,frontend' }}
+      HOMELAB_DEPLOYMENTS_REPO: ${{ vars.HOMELAB_DEPLOYMENTS_REPO != '' && vars.HOMELAB_DEPLOYMENTS_REPO || '' }}
+      HOMELAB_DEPLOYMENTS_BRANCH: ${{ vars.HOMELAB_DEPLOYMENTS_BRANCH != '' && vars.HOMELAB_DEPLOYMENTS_BRANCH || 'main' }}
+      HOMELAB_DEPLOYMENTS_SERVICES: ${{ vars.HOMELAB_DEPLOYMENTS_SERVICES != '' && vars.HOMELAB_DEPLOYMENTS_SERVICES || 'agent,aggregator,frontend' }}
     steps:
       - name: Check out homelab-map
         uses: actions/checkout@v4
 
-      - name: Check out app manifests
+      - name: Check out homelab-deployments
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.APP_MANIFESTS_REPO }}
-          token: ${{ secrets.APP_MANIFESTS_TOKEN }}
-          ref: ${{ env.APP_MANIFESTS_BRANCH }}
-          path: app-manifests
+          repository: ${{ env.HOMELAB_DEPLOYMENTS_REPO }}
+          token: ${{ secrets.HOMELAB_DEPLOYMENTS_TOKEN }}
+          ref: ${{ env.HOMELAB_DEPLOYMENTS_BRANCH }}
+          path: homelab-deployments
 
       - name: Update image tags
         run: |
-          service_args=$(printf ' --services %s' $(echo "${APP_MANIFESTS_SERVICES}" | tr ',' ' '))
-          python3 scripts/update_app_manifests.py \
-            --repo-path app-manifests \
+          service_args=$(printf ' --services %s' $(echo "${HOMELAB_DEPLOYMENTS_SERVICES}" | tr ',' ' '))
+          python3 scripts/update_homelab_deployments.py \
+            --repo-path homelab-deployments \
             --version "${VERSION}" \
             --registry "${REGISTRY}" \
             ${service_args}
 
-      - name: Open PR in app-manifests
+      - name: Open PR in homelab-deployments
         uses: peter-evans/create-pull-request@v6
         with:
-          path: app-manifests
-          token: ${{ secrets.APP_MANIFESTS_TOKEN }}
+          path: homelab-deployments
+          token: ${{ secrets.HOMELAB_DEPLOYMENTS_TOKEN }}
           commit-message: "chore: update homelab-map images to ${{ env.VERSION }}"
           branch: automation/homelab-map-${{ env.VERSION }}
-          base: ${{ env.APP_MANIFESTS_BRANCH }}
+          base: ${{ env.HOMELAB_DEPLOYMENTS_BRANCH }}
           title: "chore: homelab-map ${{ env.VERSION }}"
           body: |
             Update homelab-map image tags to `${{ env.VERSION }}`.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ npm install
 npm start
 ```
 
+## Automated Releases
+
+- Every merged pull request into `main` triggers the `Release` workflow. Label the PR with `feat`, `fix`, or `major release` (aliases: `feature`, `enhancement`, `bug`, `breaking`, etc.) to control the SemVer bump. Without a label the workflow defaults to a patch bump.
+- The workflow tags the merge commit (e.g., `v1.2.3`), invokes the reusable `Build and Publish Container Images` pipeline to build/push all service images with that tag, and still publishes a commit-hash fallback tag.
+- Configure the following repository settings so the automation can run:
+  - Secrets: `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, and `APP_MANIFESTS_TOKEN` (PAT with `public_repo` access) for pushing Docker images and updating the manifests repo.
+  - Variables: `REGISTRY` (e.g., `docker.io/dawker`), `APP_MANIFESTS_REPO` (owner/repo for the manifests), optional `APP_MANIFESTS_BRANCH` (default `main`), and optional `APP_MANIFESTS_SERVICES` (comma-separated list, default `agent,aggregator,frontend`).
+- After the images push, the workflow clones the configured `app-manifests` repo, uses `scripts/update_app_manifests.py` to bump every `homelab-map-*` image reference to the new tag, and opens an automated PR so the deployment picks up the fresh images.
+- You can also run the `Release` workflow manually from the Actions tab, choosing the bump size from the dropdown if you need an out-of-band release.
+
 ## Features
 
 - [x] Map overlay with node locations

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ npm start
 - Every merged pull request into `main` triggers the `Release` workflow. Label the PR with `feat`, `fix`, or `major release` (aliases: `feature`, `enhancement`, `bug`, `breaking`, etc.) to control the SemVer bump. Without a label the workflow defaults to a patch bump.
 - The workflow tags the merge commit (e.g., `v1.2.3`), invokes the reusable `Build and Publish Container Images` pipeline to build/push all service images with that tag, and still publishes a commit-hash fallback tag.
 - Configure the following repository settings so the automation can run:
-  - Secrets: `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, and `APP_MANIFESTS_TOKEN` (PAT with `public_repo` access) for pushing Docker images and updating the manifests repo.
-  - Variables: `REGISTRY` (e.g., `docker.io/dawker`), `APP_MANIFESTS_REPO` (owner/repo for the manifests), optional `APP_MANIFESTS_BRANCH` (default `main`), and optional `APP_MANIFESTS_SERVICES` (comma-separated list, default `agent,aggregator,frontend`).
-- After the images push, the workflow clones the configured `app-manifests` repo, uses `scripts/update_app_manifests.py` to bump every `homelab-map-*` image reference to the new tag, and opens an automated PR so the deployment picks up the fresh images.
+  - Secrets: `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, and `HOMELAB_DEPLOYMENTS_TOKEN` (PAT with `public_repo` access) for pushing Docker images and updating the deployments repo.
+  - Variables: `REGISTRY` (e.g., `docker.io/dawker`), `HOMELAB_DEPLOYMENTS_REPO` (owner/repo for the manifests), optional `HOMELAB_DEPLOYMENTS_BRANCH` (default `main`), and optional `HOMELAB_DEPLOYMENTS_SERVICES` (comma-separated list, default `agent,aggregator,frontend`).
+- After the images push, the workflow clones the configured `homelab-deployments` repo, uses `scripts/update_homelab_deployments.py` to bump every `homelab-map-*` image reference to the new tag, and opens an automated PR so the deployment picks up the fresh images.
 - You can also run the `Release` workflow manually from the Actions tab, choosing the bump size from the dropdown if you need an out-of-band release.
 
 ## Features

--- a/scripts/update_app_manifests.py
+++ b/scripts/update_app_manifests.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Update image tags inside the external app-manifests repository.
+
+The script searches YAML/JSON files for homelab-map images and replaces the tag with
+the provided version while keeping the registry/namespace portion untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from typing import Dict
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-path",
+        required=True,
+        type=pathlib.Path,
+        help="Path to the cloned app-manifests repository",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Full image tag (e.g., v1.2.3) that should replace the existing tag",
+    )
+    parser.add_argument(
+        "--registry",
+        required=True,
+        help="Registry/namespace prefix that appears before the image name",
+    )
+    parser.add_argument(
+        "--services",
+        nargs="+",
+        default=["agent", "aggregator", "frontend"],
+        help="Service suffixes to update (default: agent aggregator frontend)",
+    )
+    return parser.parse_args()
+
+
+def iter_target_files(repo_path: pathlib.Path):
+    allowed_suffixes = {".yml", ".yaml", ".json"}
+    for path in repo_path.rglob("*"):
+        if path.is_file() and path.suffix.lower() in allowed_suffixes:
+            yield path
+
+
+def update_files(
+    repo_path: pathlib.Path, version: str, services, registry: str
+) -> Dict[str, int]:
+    registry = registry.strip().rstrip("/")
+    if registry:
+        escaped_registry = re.escape(registry)
+        pattern_template = (
+            rf"((?:{escaped_registry}/)?(?:[\w.\-]+/)*{{image}}:)([A-Za-z0-9._-]+)"
+        )
+    else:
+        pattern_template = r"((?:[\w.\-]+/)*{image}:)([A-Za-z0-9._-]+)"
+    replacements: Dict[str, int] = {svc: 0 for svc in services}
+
+    for file_path in iter_target_files(repo_path):
+        original = file_path.read_text()
+        updated = original
+
+        for svc in services:
+            image = f"homelab-map-{svc}"
+            pattern = re.compile(pattern_template.format(image=re.escape(image)))
+
+            def _replace(match: re.Match) -> str:
+                replacements[svc] += 1
+                prefix = match.group(1)
+                current_tag = match.group(2)
+                if current_tag == version:
+                    return match.group(0)
+                return f"{prefix}{version}"
+
+            updated = pattern.sub(_replace, updated)
+
+        if updated != original:
+            file_path.write_text(updated)
+
+    return replacements
+
+
+def main() -> None:
+    args = parse_args()
+    repo_path: pathlib.Path = args.repo_path.resolve()
+    if not repo_path.exists():
+        sys.exit(f"Repo path {repo_path} does not exist")
+
+    replacement_counts = update_files(repo_path, args.version, args.services, args.registry)
+    missing = [svc for svc, count in replacement_counts.items() if count == 0]
+    if missing:
+        sys.exit(
+            "Failed to update tags for: "
+            + ", ".join(f"homelab-map-{svc}" for svc in missing)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_homelab_deployments.py
+++ b/scripts/update_homelab_deployments.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Update image tags inside the external app-manifests repository.
+Update image tags inside the external homelab-deployments repository.
 
 The script searches YAML/JSON files for homelab-map images and replaces the tag with
 the provided version while keeping the registry/namespace portion untouched.
@@ -21,7 +21,7 @@ def parse_args() -> argparse.Namespace:
         "--repo-path",
         required=True,
         type=pathlib.Path,
-        help="Path to the cloned app-manifests repository",
+        help="Path to the cloned homelab-deployments repository",
     )
     parser.add_argument(
         "--version",


### PR DESCRIPTION
## Summary
- introduce release workflow that bumps tags using PR labels
- reuse the build-and-publish workflow so images push with the new version
- update README and add script to sync app-manifests

## Testing
- python3 scripts/update_app_manifests.py --help