### PR TITLE
fix: avoid release workflow startup failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,16 @@ jobs:
       - name: Determine version bump
         id: bump_level
         uses: actions/github-script@v7
-        env:
-          MANUAL_BUMP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump || '' }}
-          LABELS_JSON: ${{ steps.pr_metadata.outputs.labels || '[]' }}
         if: github.event_name == 'workflow_dispatch' || steps.pr_metadata.outputs.has_pr == 'true'
+        env:
+          LABELS_JSON: ${{ steps.pr_metadata.outputs.labels || '[]' }}
         with:
           result-encoding: string
           script: |
-            const manual = process.env.MANUAL_BUMP;
+            const manual =
+              context.eventName === 'workflow_dispatch'
+                ? (context.payload?.inputs?.bump || '')
+                : '';
             if (manual) {
               core.info(`Using manual bump: ${manual}`);
               return manual;


### PR DESCRIPTION
## Summary
- remove direct references to `github.event.inputs` so push events no longer crash the workflow parser
- detect workflow_dispatch bump input inside github-script using `context.payload.inputs`
- keep existing label parsing via env, so label-driven version bumps still work

## Testing
- python3 scripts/update_homelab_deployments.py --help