### PR TITLE
fix: hardcode homelab deployments repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
-  HOMELAB_DEPLOYMENTS_REPO: ${{ vars.HOMELAB_DEPLOYMENTS_REPO != '' && vars.HOMELAB_DEPLOYMENTS_REPO || '' }}
+  HOMELAB_DEPLOYMENTS_REPO: ${{ vars.HOMELAB_DEPLOYMENTS_REPO != '' && vars.HOMELAB_DEPLOYMENTS_REPO || 'slashr/homelab-deployments' }}
   HOMELAB_DEPLOYMENTS_BRANCH: ${{ vars.HOMELAB_DEPLOYMENTS_BRANCH != '' && vars.HOMELAB_DEPLOYMENTS_BRANCH || 'main' }}
   HOMELAB_DEPLOYMENTS_SERVICES: ${{ vars.HOMELAB_DEPLOYMENTS_SERVICES != '' && vars.HOMELAB_DEPLOYMENTS_SERVICES || 'agent,aggregator,frontend' }}
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ npm start
 - The workflow tags the merge commit (e.g., `v1.2.3`), invokes the reusable `Build and Publish Container Images` pipeline to build/push all service images with that tag, and still publishes a commit-hash fallback tag.
 - Configure the following repository settings so the automation can run:
   - Secrets: `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, and `HOMELAB_DEPLOYMENTS_TOKEN` (PAT with `public_repo` access) for pushing Docker images and updating the deployments repo.
-  - Variables: `REGISTRY` (e.g., `docker.io/dawker`), `HOMELAB_DEPLOYMENTS_REPO` (owner/repo for the manifests), optional `HOMELAB_DEPLOYMENTS_BRANCH` (default `main`), and optional `HOMELAB_DEPLOYMENTS_SERVICES` (comma-separated list, default `agent,aggregator,frontend`).
+  - Variables: `REGISTRY` (e.g., `docker.io/dawker`), `HOMELAB_DEPLOYMENTS_REPO` (defaults to `slashr/homelab-deployments`, override if your manifests live elsewhere), optional `HOMELAB_DEPLOYMENTS_BRANCH` (default `main`), and optional `HOMELAB_DEPLOYMENTS_SERVICES` (comma-separated list, default `agent,aggregator,frontend`).
 - After the images push, the workflow clones the configured `homelab-deployments` repo, uses `scripts/update_homelab_deployments.py` to bump every `homelab-map-*` image reference to the new tag, and opens an automated PR so the deployment picks up the fresh images.
 - You can also run the `Release` workflow manually from the Actions tab, choosing the bump size from the dropdown if you need an out-of-band release.
 


### PR DESCRIPTION
## Summary
- default `HOMELAB_DEPLOYMENTS_REPO` to `slashr/homelab-deployments` so the release workflow always knows where to push manifests
- mention the new default in README; repo variables can still override it when needed

## Testing
- python3 scripts/update_homelab_deployments.py --help