### PR TITLE
chore: set explicit CI run name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+run-name: CI
 
 on:
   push:


### PR DESCRIPTION
## Summary
- add `run-name: CI` so Actions displays the workflow run simply as "CI" instead of the auto-generated merge description

## Testing
- not run (workflow metadata only)