### PR TITLE
fix: restore release workflow heredoc indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
               env_file.write(f"RELEASE_ENABLED={enabled}\n")
-PY
+          PY
 
       - name: Determine version bump
         id: bump_level


### PR DESCRIPTION
## Summary
- indent the inline Python terminator so GitHub Actions treats it as part of the run step
- keep the release gate script intact so skip-label handling and env propagation work again

## Testing
- not run (workflow syntax fix only); CI run on the PR will validate