### PR TITLE
fix: ensure homelab deployments update runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,17 +225,17 @@ PY
     needs:
       - prepare-release
       - build-and-push
-    if: vars.HOMELAB_DEPLOYMENTS_REPO != '' && needs.prepare-release.outputs.version != '' && needs.prepare-release.outputs.release_enabled == 'true'
+    if: env.HOMELAB_DEPLOYMENTS_REPO != '' && needs.prepare-release.outputs.version != '' && needs.prepare-release.outputs.release_enabled == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     env:
       VERSION: ${{ needs.prepare-release.outputs.version }}
-      REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
-      HOMELAB_DEPLOYMENTS_REPO: ${{ vars.HOMELAB_DEPLOYMENTS_REPO != '' && vars.HOMELAB_DEPLOYMENTS_REPO || '' }}
-      HOMELAB_DEPLOYMENTS_BRANCH: ${{ vars.HOMELAB_DEPLOYMENTS_BRANCH != '' && vars.HOMELAB_DEPLOYMENTS_BRANCH || 'main' }}
-      HOMELAB_DEPLOYMENTS_SERVICES: ${{ vars.HOMELAB_DEPLOYMENTS_SERVICES != '' && vars.HOMELAB_DEPLOYMENTS_SERVICES || 'agent,aggregator,frontend' }}
+      REGISTRY: ${{ env.REGISTRY }}
+      HOMELAB_DEPLOYMENTS_REPO: ${{ env.HOMELAB_DEPLOYMENTS_REPO }}
+      HOMELAB_DEPLOYMENTS_BRANCH: ${{ env.HOMELAB_DEPLOYMENTS_BRANCH }}
+      HOMELAB_DEPLOYMENTS_SERVICES: ${{ env.HOMELAB_DEPLOYMENTS_SERVICES }}
     steps:
       - name: Check out homelab-map
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
               env_file.write(f"RELEASE_ENABLED={enabled}\n")
-PY
+          PY
 
       - name: Determine version bump
         id: bump_level


### PR DESCRIPTION
## Summary
- gate the homelab deployments job on env.HOMELAB_DEPLOYMENTS_REPO so the default repo value is honored
- reuse the computed workflow env values for registry/branch/services instead of empty vars lookups

## Testing
- not run (workflow-only change)
