### PR TITLE
fix: allow release homelab job to run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,17 +225,17 @@ jobs:
     needs:
       - prepare-release
       - build-and-push
-    if: env.HOMELAB_DEPLOYMENTS_REPO != '' && needs.prepare-release.outputs.version != '' && needs.prepare-release.outputs.release_enabled == 'true'
+    if: needs.prepare-release.outputs.version != '' && needs.prepare-release.outputs.release_enabled == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     env:
       VERSION: ${{ needs.prepare-release.outputs.version }}
-      REGISTRY: ${{ env.REGISTRY }}
-      HOMELAB_DEPLOYMENTS_REPO: ${{ env.HOMELAB_DEPLOYMENTS_REPO }}
-      HOMELAB_DEPLOYMENTS_BRANCH: ${{ env.HOMELAB_DEPLOYMENTS_BRANCH }}
-      HOMELAB_DEPLOYMENTS_SERVICES: ${{ env.HOMELAB_DEPLOYMENTS_SERVICES }}
+      REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io/dawker' }}
+      HOMELAB_DEPLOYMENTS_REPO: ${{ vars.HOMELAB_DEPLOYMENTS_REPO != '' && vars.HOMELAB_DEPLOYMENTS_REPO || 'slashr/homelab-deployments' }}
+      HOMELAB_DEPLOYMENTS_BRANCH: ${{ vars.HOMELAB_DEPLOYMENTS_BRANCH != '' && vars.HOMELAB_DEPLOYMENTS_BRANCH || 'main' }}
+      HOMELAB_DEPLOYMENTS_SERVICES: ${{ vars.HOMELAB_DEPLOYMENTS_SERVICES != '' && vars.HOMELAB_DEPLOYMENTS_SERVICES || 'agent,aggregator,frontend' }}
     steps:
       - name: Check out homelab-map
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- drop the guard that required a non-empty env var before running update-homelab-deployments
- inject fallback values for registry/repo/branch/services directly from vars to avoid undefined env lookups

## Testing
- not run (workflow-only change)
