### PR TITLE
fix: push homelab-deployments updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,4 +279,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "chore: update homelab-map images to $VERSION"
-          git push "https://x-access-token:${{ secrets.HOMELAB_DEPLOYMENTS_TOKEN }}@github.com/slashr/homelab-deployments.git" HEAD:main
+          git push "https://x-access-token:${{ secrets.HOMELAB_DEPLOYMENTS_TOKEN }}@github.com/slashr/homelab-deployments.git" HEAD:${HOMELAB_DEPLOYMENTS_BRANCH}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,18 +267,16 @@ jobs:
             --registry "${REGISTRY}" \
             --services "${service_list[@]}"
 
-      - name: Open PR in homelab-deployments
-        uses: peter-evans/create-pull-request@v6
-        with:
-          path: homelab-deployments
-          token: ${{ secrets.HOMELAB_DEPLOYMENTS_TOKEN }}
-          commit-message: "chore: update homelab-map images to ${{ env.VERSION }}"
-          branch: automation/homelab-map-${{ env.VERSION }}
-          base: ${{ env.HOMELAB_DEPLOYMENTS_BRANCH }}
-          title: "chore: homelab-map ${{ env.VERSION }}"
-          body: |
-            Update homelab-map image tags to `${{ env.VERSION }}`.
-          labels: |
-            automated
-            homelab-map
-          delete-branch: true
+      - name: Commit and push deployments update
+        run: |
+          set -euo pipefail
+          cd homelab-deployments
+          if git diff --quiet; then
+            echo "No image updates detected"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: update homelab-map images to $VERSION"
+          git push "https://x-access-token:${{ secrets.HOMELAB_DEPLOYMENTS_TOKEN }}@github.com/slashr/homelab-deployments.git" HEAD:main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ These steps apply only when a task explicitly calls out the “FAW” (Fully Aut
 8. After merging, watch the follow-up automation (e.g., the Release workflow) until it finishes and respond to any failures.
 9. If a post-merge run fails, immediately investigate the error and open a new PR that fixes it. You may trigger this recovery flow up to three times (three consecutive merged PRs followed by failing automation runs). After the third failure, stop retrying and escalate instead of opening more PRs under FAW.
 10. Once the post-merge automation succeeds, pick the next pending item from `TASKS.md` (if present) and start work on it while keeping the FAW rules in mind.
+11. Before asking for the thumbs-up or merging, explicitly read Codex’s latest review/comments to make sure any suggestions are captured–don’t rely solely on reactions.
 
 ## Python services (`agent/`, `aggregator/`)
 - Follow the existing module layout: top-level docstring, imports grouped stdlib → third-party,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ These steps apply only when a task explicitly calls out the “FAW” (Fully Aut
 9. If a post-merge run fails, immediately investigate the error and open a new PR that fixes it. You may trigger this recovery flow up to three times (three consecutive merged PRs followed by failing automation runs). After the third failure, stop retrying and escalate instead of opening more PRs under FAW.
 10. Once the post-merge automation succeeds, pick the next pending item from `TASKS.md` (if present) and start work on it while keeping the FAW rules in mind.
 11. Before asking for the thumbs-up or merging, explicitly read Codex’s latest review/comments to make sure any suggestions are captured–don’t rely solely on reactions.
+12. After implementing any Codex feedback, reply inline via the original review thread (use the Reply action) so the action taken stays attached to the comment rather than creating a separate message.
 
 ## Python services (`agent/`, `aggregator/`)
 - Follow the existing module layout: top-level docstring, imports grouped stdlib → third-party,


### PR DESCRIPTION
## Summary
- stop creating a pull request in homelab-deployments and instead commit+push updates to main directly after tagging
- keep the job idempotent by skipping the push when no files changed

## Testing
- not run (workflow-only change)
