### PR TITLE
Fix React Hooks rules violation [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -327,14 +327,6 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     [onNodeSelect]
   );
 
-  if (nodesWithLocation.length === 0) {
-    return (
-      <div className="cluster-map empty">
-        <p>No nodes with location data available</p>
-      </div>
-    );
-  }
-
   // Handle Escape key to deselect
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -355,6 +347,14 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       onNodeDeselect?.();
     }
   }, [onNodeDeselect]);
+
+  if (nodesWithLocation.length === 0) {
+    return (
+      <div className="cluster-map empty">
+        <p>No nodes with location data available</p>
+      </div>
+    );
+  }
 
   return (
     <div 


### PR DESCRIPTION
## Summary
Fixes React Hooks rules violation by moving hooks before early return statement.

## Problem
Build was failing with:
- Line 339:3: React Hook "useEffect" is called conditionally
- Line 352:26: React Hook "useCallback" is called conditionally

## Solution
Moved all hooks (useEffect and useCallback) before the early return statement to comply with React Hooks rules.

## Acceptance Criteria
- [x] All hooks are called before any conditional returns
- [x] Build passes successfully
- [x] No React Hooks rules violations