### PR TITLE
Further reduce node info card size [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -110,11 +110,11 @@
 
 .node-info-card {
   position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  width: clamp(240px, 18vw, 280px);
-  border-radius: 12px;
-  padding: 0.875rem;
+  top: 1rem;
+  right: 1rem;
+  width: clamp(200px, 14vw, 240px);
+  border-radius: 8px;
+  padding: 0.625rem;
   backdrop-filter: blur(14px);
   box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
   z-index: 5;
@@ -135,9 +135,9 @@
 .node-info-card__header {
   display: flex;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.4rem;
   align-items: flex-start;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .node-info-card__header-right {
@@ -151,12 +151,12 @@
   background: transparent;
   border: none;
   color: inherit;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
-  padding: 0.25rem;
-  width: 24px;
-  height: 24px;
+  padding: 0.2rem;
+  width: 20px;
+  height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -182,19 +182,21 @@
 
 .node-info-card__header h3 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.2;
 }
 
 .node-info-card__header p {
-  margin: 0;
+  margin: 0.125rem 0 0 0;
   opacity: 0.8;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
+  line-height: 1.2;
 }
 
 .status-pill {
   text-transform: uppercase;
-  font-size: 0.7rem;
-  padding: 0.25rem 0.65rem;
+  font-size: 0.6rem;
+  padding: 0.2rem 0.5rem;
   border-radius: 999px;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -218,15 +220,16 @@
 .node-info-card__body {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.4rem;
 }
 
 .info-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.8rem;
-  gap: 0.5rem;
+  font-size: 0.7rem;
+  gap: 0.4rem;
+  line-height: 1.3;
 }
 
 .info-row span {
@@ -234,10 +237,10 @@
 }
 
 .info-row code {
-  font-size: 0.8rem;
+  font-size: 0.65rem;
   background: rgba(0, 0, 0, 0.08);
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 1px 4px;
+  border-radius: 3px;
 }
 
 .node-info-card.dark .info-row code {
@@ -248,8 +251,8 @@
 .metrics-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.5rem;
-  font-size: 0.75rem;
+  gap: 0.35rem;
+  font-size: 0.65rem;
 }
 
 .metrics-grid span {
@@ -258,12 +261,12 @@
 }
 
 .metrics-grid strong {
-  font-size: 0.9rem;
+  font-size: 0.75rem;
 }
 
 @media (max-width: 1100px) {
   .node-info-card {
-    width: clamp(220px, 32vw, 260px);
+    width: clamp(180px, 28vw, 220px);
   }
 }
 


### PR DESCRIPTION
## Summary
Further reduces the node info card size to make it much more compact and less intrusive.

## Changes
- Reduced width from clamp(240px, 18vw, 280px) to clamp(200px, 14vw, 240px)
- Reduced padding from 0.875rem to 0.625rem
- Reduced all font sizes further (header: 0.875rem, body: 0.7rem, metrics: 0.65rem)
- Reduced spacing and gaps throughout
- Made close button smaller (20px instead of 24px)
- Positioned card closer to edges (1rem instead of 1.5rem)

## Acceptance Criteria
- [x] Node info card is significantly smaller
- [x] Card still displays all information clearly
- [x] Works in both light and dark modes
- [x] Responsive on different screen sizes