### PR TITLE
Fix info card sizing for globe vs flat map views [AXP]

### DIFF
--- a/.axp/TRACE.md
+++ b/.axp/TRACE.md
@@ -1,0 +1,4 @@
+2025-11-14T23:22:36Z | Created PR #64: Add map mode toggle and UX improvements [AXP] | https://github.com/slashr/homelab-map/pull/64
+2025-11-14T23:22:37Z | PR #64 checks passed | Waiting for Codex review (👀)
+2025-11-14T23:45:44Z | PR #64 merged and Release workflow completed | https://github.com/slashr/homelab-map/actions/runs/19380477034
+2025-11-14T23:45:56Z | Task completed: Map mode toggle and UX improvements | PR #64 merged, Release workflow passed

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,53 +1,38 @@
-# ExecPlan: Map Mode Toggle & UX Improvements
+# ExecPlan: Fix Info Card Sizing for Globe vs Flat Map
 
-## Goal
-1. Add two map modes: flat world map and globe view with toggle
-2. Remove restrictions from globe rotation (allow full top-bottom rotation)
-3. Reduce node info card size to prevent it from covering other elements
-4. Improve network connection animation (smoother, slower, dotted but continuous lines)
+## Problem Analysis
 
-## Problems
-1. Only globe view available - no flat map option
-2. Globe rotation is restricted to horizontal view only
-3. Node info card is too large and covers map elements
-4. Network connection animations are too fast and not smooth enough
+After browser inspection, I found:
+- **Globe view**: Info card is 160px wide, covering too much of the 3D globe (parent: 1479px wide)
+- **Flat map view**: Info card is also 160px wide, but user reports it's too small
+- **Root cause**: Both views share the same CSS class `.node-info-card` with `width: clamp(140px, 10vw, 160px)`
 
 ## Solution
 
-### 1. Map Mode Toggle
-- Add toggle button in header (🗺️/🌍) to switch between globe and flat map
-- Create new `FlatMap` component using d3-geo with Mercator projection
-- Store mode preference in localStorage
-- Both modes share same node selection and info card functionality
+Create separate styles for each view:
+1. **Globe view**: Smaller card - `clamp(100px, 8vw, 120px)` to reduce obstruction
+2. **Flat map view**: Larger card - `clamp(180px, 15vw, 240px)` for better readability
 
-### 2. Remove Globe Rotation Restrictions
-- Remove `minPolarAngle` and `maxPolarAngle` constraints
-- Allow full 360-degree rotation in all directions
-- Remove constraint enforcement code
+## Implementation
 
-### 3. Reduce Info Card Size
-- Reduce width from `clamp(160px, 12vw, 200px)` to `clamp(140px, 10vw, 160px)`
-- Reduce padding and font sizes throughout
-- Reduce gaps and margins for more compact layout
+1. Add modifier classes to differentiate views:
+   - Globe: `node-info-card--globe`
+   - Flat: `node-info-card--flat`
 
-### 4. Improve Connection Animation
-- **Globe mode**: Increase `arcDashLength` to 0.6, `arcDashGap` to 0.3, `arcDashAnimateTime` to 4000ms
-- **Flat map mode**: Implement smooth requestAnimationFrame animation with `stroke-dasharray: '10 5'` for dotted continuous lines
+2. Update CSS with view-specific sizing:
+   - `.node-info-card--globe`: Smaller width, adjusted font sizes
+   - `.node-info-card--flat`: Larger width, more comfortable reading
+
+3. Update component JSX to include modifier classes
 
 ## Changes
-- `frontend/src/App.tsx`: Add map mode state and toggle button
-- `frontend/src/App.css`: Style header-right and map-mode-toggle button
-- `frontend/src/components/ClusterMap.tsx`: Remove rotation restrictions, improve animation
-- `frontend/src/components/ClusterMap.css`: Reduce info card sizes
-- `frontend/src/components/FlatMap.tsx`: New component for flat map view
-- `frontend/src/components/FlatMap.css`: Styles for flat map
-- `frontend/package.json`: Add d3-geo and d3-selection dependencies
+- `frontend/src/components/ClusterMap.tsx`: Add `node-info-card--globe` class
+- `frontend/src/components/FlatMap.tsx`: Add `node-info-card--flat` class  
+- `frontend/src/components/ClusterMap.css`: Add `.node-info-card--globe` styles with smaller sizing
+- `frontend/src/components/FlatMap.css`: Add `.node-info-card--flat` styles with larger sizing
 
 ## Validation
-- Test locally with `npm start`
-- Verify globe/flat map toggle works and persists preference
-- Test unrestricted globe rotation in all directions
-- Verify info card is smaller and doesn't cover nodes
-- Test smooth, slow connection animations in both modes
+- Test in browser: Globe view card should be smaller (~120px max)
+- Test in browser: Flat map card should be larger (~240px max)
+- Verify content is readable in both views
 - Test in both light and dark modes
-- Verify node selection works in both map modes

--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -112,12 +112,17 @@
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  width: clamp(140px, 10vw, 160px);
   border-radius: 6px;
   padding: 0.4rem;
   backdrop-filter: blur(14px);
   box-shadow: 0 15px 35px rgba(0, 0, 0, 0.25);
   z-index: 5;
+}
+
+/* Globe view: Smaller card to avoid covering the 3D globe */
+/* Use higher specificity to override .globe-wrapper > * */
+.globe-wrapper .node-info-card--globe {
+  width: clamp(100px, 8vw, 120px) !important;
 }
 
 .node-info-card.dark {
@@ -267,20 +272,22 @@
 }
 
 @media (max-width: 1100px) {
-  .node-info-card {
-    width: clamp(130px, 20vw, 150px);
+  .globe-wrapper .node-info-card--globe {
+    width: clamp(90px, 18vw, 110px) !important;
   }
 }
 
 @media (max-width: 900px) {
-  .node-info-card {
+  .node-info-card--globe,
+  .node-info-card--flat {
     position: static;
     margin: 1rem;
   }
 }
 
 @media (max-width: 700px) {
-  .node-info-card {
+  .node-info-card--globe,
+  .node-info-card--flat {
     position: fixed;
     left: 50%;
     right: auto;

--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -424,7 +424,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
         {selectedNode && (
           <div 
-            className={`node-info-card ${darkMode ? 'dark' : 'light'}`}
+            className={`node-info-card node-info-card--globe ${darkMode ? 'dark' : 'light'}`}
             onClick={(e) => e.stopPropagation()}
           >
             <div className="node-info-card__header">

--- a/frontend/src/components/FlatMap.css
+++ b/frontend/src/components/FlatMap.css
@@ -60,6 +60,17 @@
   transition: opacity 0.2s ease, stroke-width 0.2s ease;
 }
 
+/* Flat map view: Larger card for better readability on 2D map */
+.flat-map-wrapper .node-info-card--flat {
+  width: clamp(180px, 15vw, 240px) !important;
+}
+
+@media (max-width: 1100px) {
+  .flat-map-wrapper .node-info-card--flat {
+    width: clamp(160px, 20vw, 220px) !important;
+  }
+}
+
 /* Reuse arc-tooltip styles from ClusterMap.css */
 .arc-tooltip {
   border-radius: 8px;

--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -474,7 +474,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
 
         {selectedNode && (
           <div 
-            className={`node-info-card ${darkMode ? 'dark' : 'light'}`}
+            className={`node-info-card node-info-card--flat ${darkMode ? 'dark' : 'light'}`}
             onClick={(e) => e.stopPropagation()}
           >
             <div className="node-info-card__header">


### PR DESCRIPTION
## Problem
The info card was using the same size (160px) for both globe and flat map views, causing:
- Globe view: Card too large, covering too much of the 3D globe
- Flat map view: Card too small, hard to read

## Solution
- Added view-specific modifier classes: `node-info-card--globe` and `node-info-card--flat`
- Globe view: Reduced to `clamp(100px, 8vw, 120px)` - smaller to avoid obstructing the 3D view
- Flat map view: Increased to `clamp(180px, 15vw, 240px)` - larger for better readability on 2D map
- Used `!important` to override `.globe-wrapper > *` rule that was forcing 100% width

## Testing
- ✅ Verified in browser: Globe card is now 120px (was 160px)
- ✅ Verified in browser: Flat map card is now 240px (was 160px)
- ✅ Both views display correctly with appropriate sizing
- ✅ Responsive breakpoints updated for both views

## Acceptance Checklist
- [x] Globe view info card is smaller (~120px max)
- [x] Flat map view info card is larger (~240px max)
- [x] Content is readable in both views
- [x] Works in both light and dark modes
- [x] Responsive behavior maintained