### PR TITLE
Fix globe mode popup scrolling [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -122,6 +122,8 @@
 /* Use higher specificity to override .globe-wrapper > * */
 .globe-wrapper .node-info-card--globe {
   width: clamp(180px, 15vw, 240px) !important;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .node-info-card.dark {


### PR DESCRIPTION
## Problem
In globe mode, clicking on a node shows a popup that is too long and mostly empty, with relevant information only at the very top. The popup lacks proper height constraints and scrolling.

## Solution
Added  and  to the  CSS class to ensure the popup has a reasonable maximum height and becomes scrollable when content exceeds that height.

## Changes
- Modified  to add max-height and overflow-y properties to 

## Testing
- Verified the fix by reviewing the CSS changes
- The popup will now be constrained to 60% of viewport height and scrollable when needed