### PR TITLE
Fix globe popup positioning when node selected from sidebar [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -288,17 +288,33 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       if (selectedMarker && globeWrapperRef.current) {
         const markerRect = selectedMarker.getBoundingClientRect();
         const wrapperRect = globeWrapperRef.current.getBoundingClientRect();
-        setNodeCardPosition({
-          x: markerRect.left + markerRect.width / 2 - wrapperRect.left,
-          y: markerRect.top - wrapperRect.top,
-        });
+        
+        // Check if marker is actually visible (has valid dimensions and is in viewport)
+        // Allow partial visibility - just check that it's not completely off-screen
+        const isVisible = 
+          markerRect.width > 0 && 
+          markerRect.height > 0 &&
+          markerRect.bottom > wrapperRect.top &&
+          markerRect.top < wrapperRect.bottom &&
+          markerRect.right > wrapperRect.left &&
+          markerRect.left < wrapperRect.right;
+        
+        if (isVisible) {
+          setNodeCardPosition({
+            x: markerRect.left + markerRect.width / 2 - wrapperRect.left,
+            y: markerRect.top - wrapperRect.top,
+          });
+        } else {
+          // Marker not visible yet, keep trying
+          setNodeCardPosition(null);
+        }
       } else {
         setNodeCardPosition(null);
       }
     };
 
-    // Initial position with a small delay to allow DOM to update
-    const timeout = setTimeout(updatePosition, 100);
+    // Wait for globe rotation to complete (900ms animation + buffer) before initial positioning
+    const timeout = setTimeout(updatePosition, 1000);
     
     // Update on interval for smooth tracking as globe rotates
     const interval = setInterval(updatePosition, 100);


### PR DESCRIPTION
## Problem
When clicking on a node in the sidebar (e.g., toby-gcp1), the info popup appears but is empty. The popup only shows content after manually rotating the globe down to see the node.

## Root Cause
The popup position is calculated immediately (100ms delay) while the globe rotation animation takes 900ms. This causes the popup to be positioned before the marker is visible, resulting in an empty popup in the wrong location.

## Solution
1. Increased initial delay from 100ms to 1000ms to wait for globe rotation animation to complete
2. Added visibility check to ensure marker is actually in viewport before positioning popup
3. Popup now waits for globe to rotate to the selected node before appearing

## Changes
- Modified `frontend/src/components/ClusterMap.tsx` to add visibility check and increase initial delay

## Testing
- Verified the fix addresses the positioning issue
- Popup now appears correctly positioned after globe rotation completes