### PR TITLE
Fix globe popup: show in center-bottom when marker not visible [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -483,13 +483,19 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
           </div>
         )}
 
-        {selectedNode && nodeCardPosition && (
+        {selectedNode && (
           <div 
             className={`node-info-card node-info-card--globe ${darkMode ? 'dark' : 'light'}`}
-            style={{
+            style={nodeCardPosition ? {
               left: `${nodeCardPosition.x}px`,
               top: `${nodeCardPosition.y - 10}px`,
               transform: 'translate(-50%, -100%)',
+            } : {
+              // Show popup in center-bottom when marker not visible yet
+              position: 'absolute',
+              left: '50%',
+              bottom: '2rem',
+              transform: 'translateX(-50%)',
             }}
             onClick={(e) => e.stopPropagation()}
           >


### PR DESCRIPTION
## Problem
When clicking on a node in the sidebar, the popup appears but is empty. The popup only shows content after manually rotating the globe to see the node.

## Root Cause
The popup only renders when `nodeCardPosition` is set. When the marker isn't visible (globe still rotating), `nodeCardPosition` is `null`, so the popup doesn't render at all, or renders in an incorrect position.

## Solution
- Always show the popup when a node is selected, regardless of marker visibility
- Use center-bottom position as fallback when marker not visible yet
- Popup will automatically move to marker position once globe rotation completes and marker becomes visible

## Changes
- Modified `frontend/src/components/ClusterMap.tsx` to always render popup when node selected
- Added fallback positioning (center-bottom) when marker not visible

## Testing
- Popup now appears immediately when node is selected from sidebar
- Popup shows in center-bottom until marker becomes visible
- Popup moves to marker position once globe rotation completes