### PR TITLE
Fix globe popup: always use center-bottom positioning [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -118,12 +118,17 @@
   pointer-events: auto;
 }
 
-/* Globe view: Same size as flat map for consistency */
+/* Globe view: Always use fixed center-bottom positioning for visibility */
 /* Use higher specificity to override .globe-wrapper > * */
 .globe-wrapper .node-info-card--globe {
   width: clamp(180px, 15vw, 240px) !important;
   max-height: 60vh;
   overflow-y: auto;
+  position: fixed !important;
+  left: 50% !important;
+  bottom: 2rem !important;
+  transform: translateX(-50%) !important;
+  z-index: 1000 !important;
 }
 
 .node-info-card.dark {

--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -486,17 +486,6 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
         {selectedNode && (
           <div 
             className={`node-info-card node-info-card--globe ${darkMode ? 'dark' : 'light'}`}
-            style={nodeCardPosition ? {
-              left: `${nodeCardPosition.x}px`,
-              top: `${nodeCardPosition.y - 10}px`,
-              transform: 'translate(-50%, -100%)',
-            } : {
-              // Show popup in center-bottom when marker not visible yet
-              position: 'absolute',
-              left: '50%',
-              bottom: '2rem',
-              transform: 'translateX(-50%)',
-            }}
             onClick={(e) => e.stopPropagation()}
           >
             <div className="node-info-card__header">


### PR DESCRIPTION
## Problem
On globe mode, popups still require rotating the globe to see them fully, and there's whitespace issues. Popups work fine on flat map.

## Root Cause
The popup was using conditional positioning - when marker was visible, it positioned relative to marker (which could be off-screen), and only used center-bottom as fallback when marker wasn't visible.

## Solution
- Always use fixed center-bottom positioning for globe mode popups (like mobile view)
- Remove all conditional positioning logic from TSX
- Let CSS handle all positioning via `.globe-wrapper .node-info-card--globe`
- Popup is now always visible without needing to rotate globe

## Changes
- Modified `frontend/src/components/ClusterMap.css` to always use fixed center-bottom positioning
- Simplified `frontend/src/components/ClusterMap.tsx` to remove inline positioning styles

## Testing
- Popup now always appears in center-bottom when node selected
- No need to rotate globe to see popup
- Consistent with mobile view behavior