### PR TITLE
Fix whitespace in globe popup: use fit-content height [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -122,6 +122,7 @@
 /* Use higher specificity to override .globe-wrapper > * */
 .globe-wrapper .node-info-card--globe {
   width: clamp(180px, 15vw, 240px) !important;
+  height: fit-content;
   max-height: 60vh;
   overflow-y: auto;
   position: fixed !important;
@@ -233,6 +234,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  flex-shrink: 0;
 }
 
 .info-row {


### PR DESCRIPTION
## Problem
Globe popup has unnecessary length and whitespace at the bottom, making it appear longer than needed.

## Root Cause
The popup had a fixed max-height but no height constraint, causing it to potentially have extra space. The body content wasn't preventing flex shrinking which could cause spacing issues.

## Solution
- Add `height: fit-content` to make popup only as tall as its content
- Add `flex-shrink: 0` to body to prevent unnecessary spacing
- Popup now sizes exactly to its content, eliminating whitespace
- Max-height still applies for scrolling when content exceeds 60vh

## Changes
- Modified `frontend/src/components/ClusterMap.css` to add fit-content height and flex-shrink

## Testing
- Popup now only takes up space needed for content
- No more whitespace at bottom
- Still scrollable if content is very long