### PR TITLE
Fix whitespace in globe popup: use flexbox layout [AXP]

### DIFF
--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -122,7 +122,6 @@
 /* Use higher specificity to override .globe-wrapper > * */
 .globe-wrapper .node-info-card--globe {
   width: clamp(180px, 15vw, 240px) !important;
-  height: fit-content;
   max-height: 60vh;
   overflow-y: auto;
   position: fixed !important;
@@ -130,6 +129,9 @@
   bottom: 2rem !important;
   transform: translateX(-50%) !important;
   z-index: 1000 !important;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 
 .node-info-card.dark {
@@ -235,6 +237,7 @@
   flex-direction: column;
   gap: 0.25rem;
   flex-shrink: 0;
+  flex-grow: 0;
 }
 
 .info-row {


### PR DESCRIPTION
## Problem
Globe popup still has unnecessary length and whitespace at the bottom despite previous fix.

## Root Cause
`height: fit-content` may not be working as expected in all browsers or may be overridden by other CSS. The popup container needs a more reliable way to size to its content.

## Solution
- Replace `height: fit-content` with flexbox layout
- Add `display: flex` and `flex-direction: column` to popup container
- Add `flex-grow: 0` to body to prevent unnecessary expansion
- Popup now uses flexbox to properly size to content

## Changes
- Modified `frontend/src/components/ClusterMap.css` to use flexbox layout instead of fit-content

## Testing
- Popup should now only take space needed for content
- No more whitespace at bottom
- Still scrollable if content exceeds max-height