### PR TITLE
fix(frontend): zoom into node location when selected in globe mode

### DIFF
--- a/frontend/src/components/ClusterMap.tsx
+++ b/frontend/src/components/ClusterMap.tsx
@@ -263,7 +263,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       return;
     }
 
-    globeRef.current.pointOfView({ lat: focusLat, lng: focusLng, altitude: 1.3 }, 900);
+    globeRef.current.pointOfView({ lat: focusLat, lng: focusLng, altitude: 0.5 }, 900);
   }, [selectedNodeId, selectionToken, focusLat, focusLng]);
 
   // Calculate node position for info card by finding the HTML marker element


### PR DESCRIPTION
## Problem
When clicking on a node in globe mode, the camera would rotate to face the node but stayed zoomed out at globe level. Users expected to zoom into the exact location of the node.

## Solution
Reduced the globe camera altitude from 1.3 to 0.5 when a node is selected. This provides a much closer view of the node's geographic location while still showing enough context.

## Testing
- Click on any node in the sidebar or on the globe
- Camera should smoothly zoom into the node's location
- User can still zoom out manually if needed