### PR TITLE
fix(frontend): remove extra empty space in globe mode info card

### DIFF
--- a/frontend/src/components/ClusterMap.css
+++ b/frontend/src/components/ClusterMap.css
@@ -122,6 +122,7 @@
 /* Use higher specificity to override .globe-wrapper > * */
 .globe-wrapper .node-info-card--globe {
   width: clamp(180px, 15vw, 240px) !important;
+  height: auto !important;
   max-height: 60vh;
   overflow-y: auto;
   position: fixed !important;
@@ -129,9 +130,6 @@
   bottom: 2rem !important;
   transform: translateX(-50%) !important;
   z-index: 1000 !important;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
 }
 
 .node-info-card.dark {


### PR DESCRIPTION
## Problem
The node info dialog in globe mode had extra empty space, making the card appear larger than necessary.

## Solution
- Added explicit `height: auto` to ensure the card only takes up as much space as its content needs
- Removed unnecessary flex layout properties that could cause the container to expand beyond content size

## Testing
- Click on any node in globe mode
- Info card should appear compact without extra empty space at bottom
- All content should still display correctly