### PR TITLE
fix(frontend): show correct avatar when selecting overlapping nodes in flat map

### DIFF
--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -363,9 +363,16 @@ const FlatMap: React.FC<FlatMapProps> = ({
         .text(label.name);
     });
 
-    // Draw nodes
+    // Draw nodes - sort so selected node renders last (on top)
     const nodesGroup = mapContent.append('g').attr('class', 'nodes');
-    nodesWithLocation.forEach((node) => {
+    const sortedNodes = [...nodesWithLocation].sort((a, b) => {
+      // Selected node should be last (rendered on top)
+      if (a.name === selectedNodeId) return 1;
+      if (b.name === selectedNodeId) return -1;
+      return 0;
+    });
+    
+    sortedNodes.forEach((node) => {
       const coords = projection([node.lng, node.lat]);
       if (!coords) return;
 


### PR DESCRIPTION
## Problem
When clicking on a node in the sidebar in flat mode, the info popup showed the correct node's data but the map displayed the wrong avatar. For example:
- Clicking on angela showed angela's info but stanley's avatar
- Clicking on jim showed jim's info but dwight's avatar

This happened when multiple nodes share the same geographic location (e.g., nodes in the same datacenter or home nodes at the same address).

## Root Cause
Nodes at the same location overlap on the map. The render order determines which avatar is visible on top. When a node was selected, its avatar could be hidden underneath another node's avatar that was rendered later in the array.

## Solution
Sort nodes before rendering so the selected node is always rendered last (on top). This ensures the selected node's avatar is visible even when it overlaps with other nodes.

## Testing
1. Have multiple nodes at the same location (e.g., angela and stanley in same Oracle datacenter)
2. Click on a node in the sidebar
3. The selected node's avatar should now be visible on the map
4. The info popup should show the correct node's details