### PR TITLE
perf: reduce unnecessary re-renders and optimize map rendering

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,12 +75,30 @@ function App() {
           prevNodes[0].name !== newNodes[0].name ||
           prevNodes[prevNodes.length - 1].name !== newNodes[newNodes.length - 1].name
         )) return newNodes;
-        // Deep comparison for actual changes
-        const nodesChanged = prevNodes.some((node, i) => {
-          const newNode = newNodes[i];
-          return !newNode || node.name !== newNode.name || 
+        // Deep comparison for actual changes - check all fields used by UI
+        // Create a map for O(1) lookup by name
+        const newNodeMap = new Map(newNodes.map(n => [n.name, n]));
+        
+        const nodesChanged = prevNodes.some((node) => {
+          const newNode = newNodeMap.get(node.name);
+          if (!newNode) return true;
+          
+          // Compare all fields that could change and are used by the UI
+          return node.name !== newNode.name ||
                  node.status !== newNode.status ||
-                 node.lat !== newNode.lat || node.lon !== newNode.lon;
+                 node.lat !== newNode.lat ||
+                 node.lon !== newNode.lon ||
+                 node.location !== newNode.location ||
+                 node.provider !== newNode.provider ||
+                 node.external_ip !== newNode.external_ip ||
+                 node.internal_ip !== newNode.internal_ip ||
+                 node.cpu_percent !== newNode.cpu_percent ||
+                 node.memory_percent !== newNode.memory_percent ||
+                 node.disk_percent !== newNode.disk_percent ||
+                 node.network_tx_bytes_per_sec !== newNode.network_tx_bytes_per_sec ||
+                 node.network_rx_bytes_per_sec !== newNode.network_rx_bytes_per_sec ||
+                 node.last_seen !== newNode.last_seen ||
+                 node.kubelet_version !== newNode.kubelet_version;
         });
         return nodesChanged ? newNodes : prevNodes;
       });


### PR DESCRIPTION
## Performance Optimizations

This PR addresses performance issues identified from profiling map.shrub.dev by reducing unnecessary re-renders and optimizing map rendering.

### Changes

1. **Data Comparison in fetchData**
   - Only update state if data has actually changed
   - Prevents unnecessary re-renders when API returns identical data
   - Uses quick comparison (length, first/last items) before deep comparison

2. **Optimized Node Existence Check**
   - Changed from O(n) `.some()` to O(1) Set lookup
   - Uses `useMemo` to cache the Set and only recalculate when nodes change

3. **Debounced Window Resize**
   - Added 150ms debounce to resize events
   - Prevents excessive re-renders during window resizing
   - Added size comparison check before updating state

4. **Cached Country Polygons Rendering**
   - Countries are static, so only render once
   - Only update colors when theme changes
   - Prevents clearing and redrawing ~200+ country paths on every update

5. **Selective Map Element Updates**
   - Only clear/redraw dynamic elements (connections, nodes, labels)
   - Preserves static country polygons between updates
   - Reduces DOM manipulation overhead

### Expected Impact

- **Reduced CPU usage** during data refreshes (every 10 seconds)
- **Smoother window resizing** with debounced updates
- **Faster map updates** by avoiding full redraws
- **Lower memory churn** from reduced DOM manipulation

### Testing

Tested on map.shrub.dev - should see significant reduction in CPU usage during:
- Data refresh cycles
- Window resizing
- Theme switching