### PR TITLE
fix: add type annotation to fix TypeScript compilation error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
         )) return newNodes;
         // Deep comparison for actual changes - check all fields used by UI
         // Create a map for O(1) lookup by name
-        const newNodeMap = new Map(newNodes.map(n => [n.name, n]));
+        const newNodeMap = new Map(newNodes.map((n: Node) => [n.name, n]));
         
         const nodesChanged = prevNodes.some((node) => {
           const newNode = newNodeMap.get(node.name);


### PR DESCRIPTION
## Fix

Adds explicit type annotation to resolve TypeScript compilation error during Docker build.

### Issue
The Docker build was failing with:
```
TS7006: Parameter 'n' implicitly has an 'any' type.
> 80 |         const newNodeMap = new Map(newNodes.map(n => [n.name, n]));
```

### Solution
Added explicit `Node` type annotation:
```typescript
const newNodeMap = new Map(newNodes.map((n: Node) => [n.name, n]));
```

This ensures the TypeScript compiler can properly type-check the map function parameter.