### PR TITLE
fix: add TypeScript type parameters and CI type-check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
         working-directory: frontend
         run: npm install
 
+      - name: Type check frontend
+        working-directory: frontend
+        run: npm run type-check
+
       - name: Run frontend test suite
         working-directory: frontend
         run: npm test -- --watchAll=false --coverage=false --verbose 2>&1 || (echo "Test failed, checking output..." && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,20 @@ jobs:
         working-directory: frontend
         run: npm install
 
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint || (echo "Linting failed. Run 'npm run lint' locally to see errors." && exit 1)
+
       - name: Type check frontend
         working-directory: frontend
         run: npm run type-check
+
+      - name: Build frontend (verify build succeeds)
+        working-directory: frontend
+        run: npm run build
+        env:
+          CI: true
+          GENERATE_SOURCEMAP: false
 
       - name: Run frontend test suite
         working-directory: frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "type-check": "tsc --noEmit",
     "eject": "react-scripts eject",
     "postinstall": "patch-package"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "type-check": "tsc --noEmit",
     "eject": "react-scripts eject",
     "postinstall": "patch-package"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
         )) return newNodes;
         // Deep comparison for actual changes - check all fields used by UI
         // Create a map for O(1) lookup by name
-        const newNodeMap = new Map(newNodes.map((n: Node) => [n.name, n]));
+        const newNodeMap = new Map<string, Node>(newNodes.map((n: Node) => [n.name, n]));
         
         const nodesChanged = prevNodes.some((node) => {
           const newNode = newNodeMap.get(node.name);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import FlatMap from './components/FlatMap';
 import StatsPanel from './components/StatsPanel';
@@ -121,8 +121,8 @@ function App() {
         if (prevConnections.length !== newConnections.length) return newConnections;
         
         // Create a map for O(1) lookup by connection key
-        const newConnMap = new Map(
-          newConnections.map(c => [`${c.source_node}-${c.target_node}`, c])
+        const newConnMap = new Map<string, Connection>(
+          newConnections.map((c: Connection) => [`${c.source_node}-${c.target_node}`, c])
         );
         
         // Compare all connections - check all fields that could change

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,3 +1,4 @@
 // Jest setup file for react-scripts
 // This file is automatically loaded by react-scripts before running tests
 
+export {};


### PR DESCRIPTION
## Fixes

This PR addresses TypeScript compilation errors and adds CI validation to catch them early.

### Changes

1. **Add explicit Map type parameters**
   - Changed `new Map(...)` to `new Map<string, Node>(...)`
   - Fixes TS2339 error: Property 'name' does not exist on type '{}'
   - Ensures TypeScript correctly infers `Map.get()` return type as `Node | undefined`

2. **Add TypeScript type-check to CI**
   - Added `type-check` script to package.json: `tsc --noEmit`
   - Added type-check step to CI workflow before running tests
   - Catches TypeScript compilation errors in CI rather than only during Docker build

### Why This Was Needed

The original tests didn't catch this because:
- `npm test` (Jest) doesn't perform full TypeScript type checking
- Jest only type-checks files that are imported by tests
- `App.tsx` isn't directly tested, so its TypeScript errors weren't caught
- Full TypeScript compilation only happened during `npm run build` in Docker

### Impact

- TypeScript errors are now caught early in CI
- Prevents Docker build failures from type errors
- Improves developer feedback loop