### PR TITLE
perf: fix high CPU and memory usage

### DIFF
--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -95,9 +95,10 @@ const FlatMap: React.FC<FlatMapProps> = ({
   const zoomTransformRef = useRef<ZoomTransform | null>(null);
   const baseScaleRef = useRef<number>(1);
   // Cache gradient stop selections to avoid re-querying DOM every frame
+  // Using 'any' for selection type to avoid complex D3 type annotations
   const gradientStopsRef = useRef<{
-    forward: ReturnType<typeof select>[];
-    reverse: ReturnType<typeof select>[];
+    forward: any[];
+    reverse: any[];
   } | null>(null);
   const isVisibleRef = useRef<boolean>(true);
 


### PR DESCRIPTION
## Performance Fixes

This PR addresses critical performance issues causing 5GB+ memory usage and 200%+ CPU usage.

### Issues Found
- **CPU: 200%+** - Animation loop re-querying DOM 600 times per second
- **Memory: 5GB+** - Continuous animation loop with no cleanup
- **No visibility handling** - Animation runs even when tab is hidden
- **Inefficient DOM queries** - 10 D3 selectAll() calls every frame

### Changes

1. **Cache D3 Gradient Stop Selections**
   - Previously: Re-queried DOM every frame (60fps) with 10 `selectAll()` calls
   - Now: Caches selections and only re-queries when connections change
   - Impact: Reduces DOM queries from 600/sec to ~0.1/sec (6000x improvement)

2. **Page Visibility API Support**
   - Pauses animation loop when tab is hidden
   - Saves CPU/memory when user switches tabs
   - Automatically resumes when tab becomes visible

3. **Stop Animation When No Connections**
   - Previously: Animation loop ran continuously even with no connections
   - Now: Stops completely when `flatMapConnections.length === 0`
   - Prevents unnecessary CPU usage

4. **Optimize Animation Loop**
   - Invalidates cache when connections change (new gradients created)
   - Uses cached selections instead of re-querying every frame
   - Reduces DOM manipulation overhead

### Expected Impact

- **CPU usage**: 200%+ → <50% (4x improvement)
- **Memory usage**: 5GB+ → <500MB (10x improvement)
- **Animation overhead**: 600 DOM queries/sec → ~0.1/sec (6000x improvement)

### Testing

Test on map.shrub.dev and verify:
- CPU usage is normal (<50%)
- Memory usage is reasonable (<500MB)
- Animation still works correctly
- Animation pauses when tab is hidden
- No visual regressions