### PR TITLE
style: change node highlight from circle to rounded square

### DIFF
--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -769,10 +769,17 @@ const FlatMap: React.FC<FlatMapProps> = ({
           onNodeSelect?.(node.name);
         });
 
-      // Node circle
+      // Node background (rounded square to match square icons)
+      const size = isSelected ? 56 : 52;
+      const offset = size / 2;
       nodeGroup
-        .append('circle')
-        .attr('r', isSelected ? 28 : 26)
+        .append('rect')
+        .attr('x', -offset)
+        .attr('y', -offset)
+        .attr('width', size)
+        .attr('height', size)
+        .attr('rx', 10)
+        .attr('ry', 10)
         .attr('fill', darkMode ? '#10101a' : '#ffffff')
         .attr('stroke', 
           node.status === 'online' ? '#4caf50' :


### PR DESCRIPTION
## Summary

Changes the node background/border from a circle to a rounded rectangle to match the square icon style.

### Before
- Circle highlight around node icons
- Didn't match the new square icon style

### After
- Rounded square highlight matching the icon shape
- 10px border radius for consistent rounded corners
- 52px size (56px when selected)
- Same status-based stroke colors (green for online, orange for warning, gray for offline)

### Screenshot
The node selection indicator now matches the square icon shape instead of being circular.

### Testing
- Verify nodes display with square backgrounds
- Verify selection highlight is square with rounded corners
- Verify status colors still work (green/orange/gray borders)