### PR TITLE
feat: replace node status with live updating 'last seen' time

### DIFF
--- a/frontend/src/components/StatsPanel.css
+++ b/frontend/src/components/StatsPanel.css
@@ -446,6 +446,32 @@
   font-weight: 600;
 }
 
+.node-last-seen {
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-panel.dark .node-last-seen {
+  color: #aaa;
+}
+
+.stats-panel.light .node-last-seen {
+  color: #666;
+}
+
+.node-last-seen.status-online {
+  color: #4caf50;
+}
+
+.node-last-seen.status-warning {
+  color: #ff9800;
+}
+
+.node-last-seen.status-offline {
+  color: #f44336;
+}
+
 .node-throughput {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary

Replaces the static 'online/offline/warning' status text next to nodes in the sidebar with a live updating relative time showing when the node was last seen.

### Before
- Shows static text like 'online', 'offline', 'warning'
- Doesn't show how recently the node was seen

### After
- Shows live updating relative time: '2s ago', '5m ago', '1h ago', '2d ago'
- Updates every second for real-time feedback
- Color-coded based on node status:
  - Green for online nodes
  - Orange for warning nodes
  - Red for offline nodes

### Implementation

- Added `formatRelativeTime()` function to convert timestamps to relative time
- Added 1-second interval timer to trigger re-renders for live updates
- Uses `font-variant-numeric: tabular-nums` for stable width during updates

### Testing

- Verify timestamps update every second
- Verify correct formatting (seconds/minutes/hours/days)
- Verify color coding matches node status
- Verify no performance issues from 1-second updates