### PR TITLE
fix: handle pre-formatted last_seen values from API

### DIFF
--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -5,12 +5,19 @@ import { getCharacterFromNodeName, getCharacterImage, getCharacterQuote } from '
 import './StatsPanel.css';
 
 // Format a timestamp as relative time (e.g., "2s ago", "5m ago")
+// The API already returns last_seen as a pre-formatted string, so we pass it through
 const formatRelativeTime = (timestamp: string): string => {
+  // If already formatted as relative time (from API), return as-is
+  if (timestamp.includes('ago') || timestamp === 'just now') {
+    return timestamp;
+  }
+  
+  // Try to parse as ISO timestamp (for future compatibility)
   const now = Date.now();
   const then = new Date(timestamp).getTime();
   const diffMs = now - then;
   
-  if (isNaN(then)) return 'unknown';
+  if (isNaN(then)) return timestamp || 'unknown';
   
   const seconds = Math.floor(diffMs / 1000);
   if (seconds < 0) return 'just now';


### PR DESCRIPTION
## Summary

Fixes the 'unknown' display for node last seen times in the sidebar.

### Problem

The `formatRelativeTime` function was trying to parse `last_seen` as an ISO timestamp using `new Date()`. However, the API already returns `last_seen` as a pre-formatted relative time string (e.g., '5s ago', '1m ago'). Parsing this with `new Date()` returns `NaN`, causing the function to return 'unknown'.

### Solution

- Check if `last_seen` already contains 'ago' or 'just now' and return as-is
- Fall back to parsing as ISO timestamp for future compatibility
- Return original timestamp if parsing fails instead of 'unknown'

### Testing

- Verify nodes now show correct last seen times (e.g., '5s ago')
- Verify clicking on nodes still shows the correct time in details view