### PR TITLE
perf: reduce frontend/map load and cap connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ A real-time visualization tool for monitoring your k3s homelab cluster across mu
 **Aggregator Environment Variables:**
 - `NODE_TIMEOUT_SECONDS`: Number of seconds before a node is marked offline. Defaults to 120.
 - `CLEANUP_GRACE_PERIOD_SECONDS`: Number of seconds after timeout before stale nodes are removed. Defaults to 86400 (24 hours).
+- `MAX_CONNECTIONS`: Maximum number of connections returned by the API. Defaults to 500.
+- `DEDUP_CONNECTIONS`: When true, collapses bidirectional connections into one entry (default: true).
 
   ```bash
   export NODE_TIMEOUT_SECONDS=300
@@ -76,6 +78,9 @@ A real-time visualization tool for monitoring your k3s homelab cluster across mu
 **Agent Environment Variables:**
 - `HOME_CITY`, `HOME_LAT`, `HOME_LON`: Override the default Berlin home marker for your on-prem nodes.
 - `ENABLE_AUTO_GEOLOCATION`: Enable automatic geolocation detection (default: true). Set to 'false' to disable.
+- `REPORT_INTERVAL`: How often to report node stats to the aggregator in seconds (default: 30).
+- `CONNECTION_CHECK_INTERVAL`: How many report cycles between connection checks (default: 5).
+- `MAX_CONNECTION_TARGETS`: Max number of nodes to ping for latency per report (default: 25).
 
   ```bash
   export HOME_CITY="Austin, TX"

--- a/SETUP.md
+++ b/SETUP.md
@@ -46,6 +46,14 @@ HOME_LOCATION = {
 
 **Note**: Cloud provider locations (Oracle, GCP) are pre-configured with their datacenter locations - no need to change those!
 
+### 2b. Optional Performance Tunables
+
+Set these in your agent/aggregator manifests to reduce connection churn on larger clusters:
+
+- Aggregator: `MAX_CONNECTIONS` (default 500), `DEDUP_CONNECTIONS` (default true)
+- Agent: `REPORT_INTERVAL` (default 30s), `CONNECTION_CHECK_INTERVAL` (default 5),
+  `MAX_CONNECTION_TARGETS` (default 25)
+
 ### 3. Build and Push Docker Images
 
 ```bash

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -502,9 +502,9 @@ def main():
     logger.info(f"Starting Homelab K3s Agent on {NODE_NAME}")
     logger.info(f"Aggregator URL: {AGGREGATOR_URL}")
     logger.info(f"Report interval: {REPORT_INTERVAL}s")
+    logger.info(f"Connection check interval: {CONNECTION_CHECK_INTERVAL} reports")
     
     connection_check_counter = 0
-    CONNECTION_CHECK_INTERVAL = 5  # Measure connections every 5 reports (2.5 minutes)
     
     while True:
         try:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -29,6 +29,16 @@ def _get_float_env(var_name: str, default: float) -> float:
     raw_value = os.getenv(var_name)
     if raw_value is None:
         return default
+    try:
+        return float(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid %s value '%s'; falling back to %s",
+            var_name,
+            raw_value,
+            default,
+        )
+        return default
 
 
 def _get_int_env(var_name: str, default: int) -> int:
@@ -79,16 +89,6 @@ HOME_LON_ENV_VAR = 'HOME_LON'
 DEFAULT_HOME_CITY = 'Berlin, Germany'
 DEFAULT_HOME_LAT = 52.5200
 DEFAULT_HOME_LON = 13.4050
-    try:
-        return float(raw_value)
-    except ValueError:
-        logger.warning(
-            "Invalid %s value '%s'; falling back to %s",
-            var_name,
-            raw_value,
-            default,
-        )
-        return default
 
 
 def _build_home_location() -> dict:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -11,6 +11,7 @@ import time
 import logging
 import subprocess
 import statistics
+import random
 import requests
 import psutil
 from typing import Optional
@@ -23,9 +24,43 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+def _get_float_env(var_name: str, default: float) -> float:
+    """Return a float from the environment or fall back to default."""
+    raw_value = os.getenv(var_name)
+    if raw_value is None:
+        return default
+
+
+def _get_int_env(var_name: str, default: int) -> int:
+    """Return an int from the environment or fall back to default."""
+    raw_value = os.getenv(var_name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid %s value '%s'; falling back to %s",
+            var_name,
+            raw_value,
+            default,
+        )
+        return default
+    if value < 0:
+        logger.warning(
+            "%s must be non-negative; falling back to %s",
+            var_name,
+            default,
+        )
+        return default
+    return value
+
+
 # Configuration from environment variables
 AGGREGATOR_URL = os.getenv('AGGREGATOR_URL', 'http://homelab-map-aggregator:8000')
-REPORT_INTERVAL = int(os.getenv('REPORT_INTERVAL', '30'))  # seconds
+REPORT_INTERVAL = _get_int_env('REPORT_INTERVAL', 30)  # seconds
+CONNECTION_CHECK_INTERVAL = _get_int_env('CONNECTION_CHECK_INTERVAL', 5)
+MAX_CONNECTION_TARGETS = _get_int_env('MAX_CONNECTION_TARGETS', 25)
 NODE_NAME = os.getenv('NODE_NAME', socket.gethostname())
 NETWORK_COUNTER_SNAPSHOT = None
 ENABLE_AUTO_GEOLOCATION = os.getenv('ENABLE_AUTO_GEOLOCATION', 'true').lower() == 'true'
@@ -44,13 +79,6 @@ HOME_LON_ENV_VAR = 'HOME_LON'
 DEFAULT_HOME_CITY = 'Berlin, Germany'
 DEFAULT_HOME_LAT = 52.5200
 DEFAULT_HOME_LON = 13.4050
-
-
-def _get_float_env(var_name: str, default: float) -> float:
-    """Return a float from the environment or fall back to default."""
-    raw_value = os.getenv(var_name)
-    if raw_value is None:
-        return default
     try:
         return float(raw_value)
     except ValueError:
@@ -440,6 +468,16 @@ def measure_connections():
     """Measure network latency to all other nodes"""
     other_nodes = get_other_nodes()
     connections = []
+
+    original_count = len(other_nodes)
+    if MAX_CONNECTION_TARGETS > 0 and original_count > MAX_CONNECTION_TARGETS:
+        random.shuffle(other_nodes)
+        other_nodes = other_nodes[:MAX_CONNECTION_TARGETS]
+        logger.info(
+            "Sampling %s connection targets out of %s nodes",
+            MAX_CONNECTION_TARGETS,
+            original_count,
+        )
     
     logger.info(f"Measuring connections to {len(other_nodes)} other nodes...")
     

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -197,6 +197,7 @@ class NodeStatus(BaseModel):
     disk_percent: Optional[float] = None
     network_tx_bytes_per_sec: Optional[float] = None
     network_rx_bytes_per_sec: Optional[float] = None
+    last_seen_timestamp: float
     last_seen: str
     kubelet_version: Optional[str] = None
 
@@ -319,6 +320,7 @@ async def get_all_nodes():
                 disk_percent=node_data.get('disk_percent'),
                 network_tx_bytes_per_sec=node_data.get('network_tx_bytes_per_sec'),
                 network_rx_bytes_per_sec=node_data.get('network_rx_bytes_per_sec'),
+                last_seen_timestamp=last_seen_timestamp,
                 last_seen=last_seen,
                 kubelet_version=node_data.get('kubelet_version')
             ))

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -110,12 +110,15 @@ async def test_get_all_nodes_reports_statuses_based_on_last_seen(
     response = await main.get_all_nodes()
     nodes = {node.name: node for node in response}
     assert nodes["node-online"].status == "online"
+    assert nodes["node-online"].last_seen_timestamp == pytest.approx(fixed_time - 30)
     assert nodes["node-online"].last_seen == "30s ago"
     assert nodes["node-online"].network_tx_bytes_per_sec == pytest.approx(2048.0)
     assert nodes["node-online"].network_rx_bytes_per_sec == pytest.approx(1024.0)
     assert nodes["node-warning"].status == "warning"
+    assert nodes["node-warning"].last_seen_timestamp == pytest.approx(fixed_time - 90)
     assert nodes["node-warning"].last_seen == "1m ago"
     assert nodes["node-offline"].status == "offline"
+    assert nodes["node-offline"].last_seen_timestamp == pytest.approx(fixed_time - 3600)
     assert nodes["node-offline"].last_seen == "1h ago"
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,6 +100,7 @@ function App() {
                  node.disk_percent !== newNode.disk_percent ||
                  node.network_tx_bytes_per_sec !== newNode.network_tx_bytes_per_sec ||
                  node.network_rx_bytes_per_sec !== newNode.network_rx_bytes_per_sec ||
+                 node.last_seen_timestamp !== newNode.last_seen_timestamp ||
                  node.last_seen !== newNode.last_seen ||
                  node.kubelet_version !== newNode.kubelet_version;
         });

--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -335,7 +335,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
         return;
       }
 
-      if (now - lastFrameTime < 50) {
+      if (now - lastFrameTime < 50) { // ~20fps throttle to limit DOM work
         animationFrameRef.current = requestAnimationFrame(animate);
         return;
       }

--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -88,7 +88,6 @@ const FlatMap: React.FC<FlatMapProps> = ({
   const [mapSize, setMapSize] = React.useState<{ width: number; height: number } | null>(null);
   const [hoveredArc, setHoveredArc] = React.useState<FlatMapConnectionDatum | null>(null);
   const [tooltipPosition, setTooltipPosition] = React.useState<{ x: number; y: number } | null>(null);
-  const [zoomTransform, setZoomTransform] = React.useState<ZoomTransform | null>(null);
   const mousePositionRef = React.useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const animationFrameRef = useRef<number>();
   const dashOffsetRef = useRef<number>(0);
@@ -127,8 +126,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
     };
   }, [hoveredArc]);
 
-  // Group nodes by city/location for hub-and-spoke layout
-  const cityGroups = useMemo(() => {
+  const nodesWithLocation = useMemo(() => {
     // First, filter nodes with valid locations
     const validNodes = nodes
       .filter(
@@ -144,121 +142,69 @@ const FlatMap: React.FC<FlatMapProps> = ({
         lng: node.lon as number,
       }));
     
-    // Group nodes by location name (city) - use the location field if available
+    // Group nodes by approximate location (within 0.01 degrees ~ 1km)
     const locationGroups = new Map<string, typeof validNodes>();
     validNodes.forEach((node) => {
-      // Use location name if available, otherwise group by rounded coords
-      const key = node.location || `${Math.round(node.lat * 10) / 10},${Math.round(node.lng * 10) / 10}`;
+      // Round to 2 decimal places to group nearby nodes
+      const key = `${Math.round(node.lat * 100) / 100},${Math.round(node.lng * 100) / 100}`;
       if (!locationGroups.has(key)) {
         locationGroups.set(key, []);
       }
       locationGroups.get(key)!.push(node);
     });
     
-    // Create city hub data with original center and spread nodes
-    const cityData: {
-      cityName: string;
-      centerLat: number;
-      centerLng: number;
-      nodes: typeof validNodes;
-    }[] = [];
-    
-    locationGroups.forEach((groupNodes, cityName) => {
-      // Calculate city center as the average of all node positions
-      const centerLat = groupNodes.reduce((sum, n) => sum + n.lat, 0) / groupNodes.length;
-      const centerLng = groupNodes.reduce((sum, n) => sum + n.lng, 0) / groupNodes.length;
-      
-      // Spread nodes in a circle around the city center
-      // Use larger radius for more nodes, minimum radius for visibility
-      const baseRadius = 2.5; // degrees offset (visible at map scale)
-      const radius = Math.max(baseRadius, groupNodes.length * 0.8);
-      
-      const spreadNodes = groupNodes.map((node, index) => {
-        // Start from top (-90°) and spread clockwise
-        const startAngle = -Math.PI / 2;
-        const angle = startAngle + (2 * Math.PI * index) / groupNodes.length;
-        return {
-          ...node,
-          // Store original lat/lng for connection calculations
-          originalLat: node.lat,
-          originalLng: node.lng,
-          // New display position spread around the city center
-          lat: centerLat + radius * Math.sin(angle),
-          lng: centerLng + radius * Math.cos(angle),
-        };
-      });
-      
-      cityData.push({
-        cityName,
-        centerLat,
-        centerLng,
-        nodes: spreadNodes,
-      });
-    });
-    
-    return cityData;
-  }, [nodes]);
-
-  // Flatten nodes for rendering, with display positions
-  const nodesWithLocation = useMemo(() => {
-    return cityGroups.flatMap(city => city.nodes);
-  }, [cityGroups]);
-
-  // Lookup to find which city a node belongs to (for routing connections through city centers)
-  const nodeToCityLookup = useMemo(() => {
-    const map = new Map<string, { centerLat: number; centerLng: number; cityName: string }>();
-    cityGroups.forEach((city) => {
-      city.nodes.forEach((node) => {
-        map.set(node.name, {
-          centerLat: city.centerLat,
-          centerLng: city.centerLng,
-          cityName: city.cityName,
+    // Apply visual offset to nodes sharing the same location
+    const result: typeof validNodes = [];
+    locationGroups.forEach((groupNodes) => {
+      if (groupNodes.length === 1) {
+        // Single node, no offset needed
+        result.push(groupNodes[0]);
+      } else {
+        // Multiple nodes at same location - spread them in a circle
+        const radius = 0.5; // degrees offset (visible at map scale)
+        groupNodes.forEach((node, index) => {
+          const angle = (2 * Math.PI * index) / groupNodes.length;
+          result.push({
+            ...node,
+            lat: node.lat + radius * Math.sin(angle),
+            lng: node.lng + radius * Math.cos(angle),
+          });
         });
-      });
-    });
-    return map;
-  }, [cityGroups]);
-
-  // Connections between city centers (for inter-city connections only)
-  const flatMapConnections = useMemo(() => {
-    // De-duplicate connections at the city level
-    const cityConnectionSet = new Set<string>();
-    const result: FlatMapConnectionDatum[] = [];
-    
-    connections.forEach((conn) => {
-      const sourceCity = nodeToCityLookup.get(conn.source_node);
-      const targetCity = nodeToCityLookup.get(conn.target_node);
-      
-      if (!sourceCity || !targetCity) {
-        return;
       }
-      
-      // Skip intra-city connections (same city)
-      if (sourceCity.cityName === targetCity.cityName) {
-        return;
-      }
-      
-      // Create a unique key for this city-to-city connection (bidirectional)
-      const cityPair = [sourceCity.cityName, targetCity.cityName].sort().join('|');
-      if (cityConnectionSet.has(cityPair)) {
-        return; // Already have this city-to-city connection
-      }
-      cityConnectionSet.add(cityPair);
-      
-      const colors = getLatencyColor(conn.latency_ms, darkMode);
-      result.push({
-        startLat: sourceCity.centerLat,
-        startLng: sourceCity.centerLng,
-        endLat: targetCity.centerLat,
-        endLng: targetCity.centerLng,
-        color: colors,
-        latency: conn.latency_ms,
-        label: `${sourceCity.cityName} ↔ ${targetCity.cityName}`,
-      });
     });
     
     return result;
-  }, [connections, nodeToCityLookup, darkMode]);
+  }, [nodes]);
+
+  const nodeLookup = useMemo(() => {
+    const map = new Map<string, { lat: number; lng: number }>();
+    nodesWithLocation.forEach((node) => {
+      map.set(node.name, { lat: node.lat, lng: node.lng });
+    });
+    return map;
+  }, [nodesWithLocation]);
+
+  const flatMapConnections = useMemo(() => {
+    return connections
+      .map((conn) => {
+        const source = nodeLookup.get(conn.source_node);
+        const target = nodeLookup.get(conn.target_node);
+        if (!source || !target) {
+          return null;
+        }
+        const colors = getLatencyColor(conn.latency_ms, darkMode);
+        return {
+          startLat: source.lat,
+          startLng: source.lng,
+          endLat: target.lat,
+          endLng: target.lng,
+          color: colors,
+          latency: conn.latency_ms,
+          label: `${conn.source_node} → ${conn.target_node}`,
+        } as FlatMapConnectionDatum;
+      })
+      .filter((value): value is FlatMapConnectionDatum => Boolean(value));
+  }, [connections, nodeLookup, darkMode]);
 
   const countryPolygons = useMemo(() => {
     const geoJson = feature(
@@ -346,6 +292,16 @@ const FlatMap: React.FC<FlatMapProps> = ({
       return;
     }
 
+    const MAX_ANIMATED_CONNECTIONS = 200;
+    if (flatMapConnections.length > MAX_ANIMATED_CONNECTIONS) {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = undefined;
+      }
+      gradientStopsRef.current = null;
+      return;
+    }
+
     const svg = select(svgRef.current);
     
     // Invalidate cache when connections change (new gradients will be created)
@@ -371,12 +327,19 @@ const FlatMap: React.FC<FlatMapProps> = ({
       };
     };
     
-    const animate = () => {
+    let lastFrameTime = 0;
+    const animate = (now: number) => {
       // Skip animation if tab is hidden
       if (!isVisibleRef.current) {
         animationFrameRef.current = requestAnimationFrame(animate);
         return;
       }
+
+      if (now - lastFrameTime < 50) {
+        animationFrameRef.current = requestAnimationFrame(animate);
+        return;
+      }
+      lastFrameTime = now;
 
       // Cache gradient stops if not cached yet (gradients created after mount)
       if (!gradientStopsRef.current) {
@@ -472,7 +435,6 @@ const FlatMap: React.FC<FlatMapProps> = ({
       })
       .on('zoom', (event: any) => {
         zoomTransformRef.current = event.transform;
-        setZoomTransform(event.transform);
         mapContent.attr('transform', event.transform.toString());
         
         // Update node scales to maintain constant size (inverse of zoom scale)
@@ -541,7 +503,6 @@ const FlatMap: React.FC<FlatMapProps> = ({
       
       // Update transform and trigger zoom event manually
       zoomTransformRef.current = interpolatedTransform;
-      setZoomTransform(interpolatedTransform);
       const mapContent = svg.select<SVGGElement>('g.map-content');
       mapContent.attr('transform', interpolatedTransform.toString());
       
@@ -569,7 +530,6 @@ const FlatMap: React.FC<FlatMapProps> = ({
         // Animation complete - update zoom behavior's transform state so further zooming works
         const finalTransform = zoomIdentity.translate(transform.x, transform.y).scale(transform.k);
         zoomTransformRef.current = finalTransform;
-        setZoomTransform(finalTransform);
         
         // Update the zoom behavior's internal state by calling transform on the selection
         // This ensures the zoom behavior knows about the current transform and allows further zooming
@@ -641,6 +601,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
     if (defs.empty()) {
       defs = svg.append('defs');
     }
+    defs.selectAll('linearGradient.connection-gradient').remove();
     
     flatMapConnections.forEach((conn, index) => {
       const start = projection([conn.startLng, conn.startLat]);
@@ -654,6 +615,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
 
       // Forward flow gradient (source to target) - aligned along the line
       const forwardGradient = defs.append('linearGradient')
+        .attr('class', 'connection-gradient')
         .attr('id', forwardGradientId)
         .attr('x1', start[0])
         .attr('y1', start[1])
@@ -690,6 +652,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
 
       // Reverse flow gradient (target to source) - opposite direction
       const reverseGradient = defs.append('linearGradient')
+        .attr('class', 'connection-gradient')
         .attr('id', reverseGradientId)
         .attr('x1', end[0])
         .attr('y1', end[1])
@@ -765,54 +728,6 @@ const FlatMap: React.FC<FlatMapProps> = ({
           setHoveredArc(null);
           setTooltipPosition(null);
         });
-    });
-
-    // Draw city hubs and spoke lines connecting city centers to nodes
-    const hubsGroup = mapContent.append('g').attr('class', 'city-hubs');
-    const spokesGroup = mapContent.append('g').attr('class', 'spoke-lines');
-    
-    cityGroups.forEach((city) => {
-      const centerCoords = projection([city.centerLng, city.centerLat]);
-      if (!centerCoords) return;
-
-      // Draw city hub marker (small circle at city center)
-      hubsGroup
-        .append('circle')
-        .attr('class', 'city-hub-marker')
-        .attr('cx', centerCoords[0])
-        .attr('cy', centerCoords[1])
-        .attr('r', 6)
-        .attr('fill', darkMode ? 'rgba(100, 180, 255, 0.9)' : 'rgba(50, 120, 200, 0.9)')
-        .attr('stroke', darkMode ? 'rgba(150, 200, 255, 0.6)' : 'rgba(30, 80, 150, 0.6)')
-        .attr('stroke-width', 2);
-
-      // Draw city name label near hub
-      hubsGroup
-        .append('text')
-        .attr('class', 'city-hub-label')
-        .attr('x', centerCoords[0])
-        .attr('y', centerCoords[1] - 12)
-        .attr('text-anchor', 'middle')
-        .attr('font-size', '11px')
-        .attr('font-weight', '600')
-        .attr('fill', darkMode ? 'rgba(200, 220, 255, 0.9)' : 'rgba(30, 60, 120, 0.9)')
-        .text(city.cityName);
-
-      // Draw spoke lines from city center to each node
-      city.nodes.forEach((node) => {
-        const nodeCoords = projection([node.lng, node.lat]);
-        if (!nodeCoords) return;
-
-        // Spoke line with gradient
-        spokesGroup
-          .append('path')
-          .attr('class', 'spoke-line')
-          .attr('d', `M ${centerCoords[0]},${centerCoords[1]} L ${nodeCoords[0]},${nodeCoords[1]}`)
-          .attr('stroke', darkMode ? 'rgba(100, 180, 255, 0.5)' : 'rgba(50, 120, 200, 0.5)')
-          .attr('stroke-width', 1.5)
-          .attr('stroke-dasharray', '4,4')
-          .attr('fill', 'none');
-      });
     });
 
     // Draw capital labels
@@ -907,28 +822,32 @@ const FlatMap: React.FC<FlatMapProps> = ({
     // Reuse the existing defs element
     defs = svg.select<SVGDefsElement>('defs');
     
-    // Shadow filter
-    defs
-      .append('filter')
-      .attr('id', 'node-shadow')
-      .append('feDropShadow')
-      .attr('dx', 0)
-      .attr('dy', 2)
-      .attr('stdDeviation', 3)
-      .attr('flood-opacity', 0.3);
+    // Shadow filter (create once)
+    if (defs.select('#node-shadow').empty()) {
+      defs
+        .append('filter')
+        .attr('id', 'node-shadow')
+        .append('feDropShadow')
+        .attr('dx', 0)
+        .attr('dy', 2)
+        .attr('stdDeviation', 3)
+        .attr('flood-opacity', 0.3);
+    }
 
-    // Clip path for square images with rounded corners
-    defs
-      .append('clipPath')
-      .attr('id', 'node-clip')
-      .append('rect')
-      .attr('x', -24)
-      .attr('y', -24)
-      .attr('width', 48)
-      .attr('height', 48)
-      .attr('rx', 8)
-      .attr('ry', 8);
-  }, [path, projection, mapSize, countryPolygons, flatMapConnections, nodesWithLocation, cityGroups, selectedNodeId, darkMode, onNodeSelect, zoomTransform]);
+    // Clip path for square images with rounded corners (create once)
+    if (defs.select('#node-clip').empty()) {
+      defs
+        .append('clipPath')
+        .attr('id', 'node-clip')
+        .append('rect')
+        .attr('x', -24)
+        .attr('y', -24)
+        .attr('width', 48)
+        .attr('height', 48)
+        .attr('rx', 8)
+        .attr('ry', 8);
+    }
+  }, [path, projection, mapSize, countryPolygons, flatMapConnections, nodesWithLocation, selectedNodeId, darkMode, onNodeSelect]);
 
   const handleMapClick = useCallback((event: React.MouseEvent) => {
     const target = event.target as Element;
@@ -1024,4 +943,3 @@ const FlatMap: React.FC<FlatMapProps> = ({
 
 // Memoize to prevent re-renders when parent state changes but props are identical
 export default memo(FlatMap);
-

--- a/frontend/src/mockData.ts
+++ b/frontend/src/mockData.ts
@@ -1,5 +1,7 @@
 import { Node, Connection, ClusterStats } from './types';
 
+const mockNow = Math.floor(Date.now() / 1000);
+
 // Mock nodes with various locations around the world
 export const mockNodes: Node[] = [
   {
@@ -17,6 +19,7 @@ export const mockNodes: Node[] = [
     disk_percent: 62.3,
     network_tx_bytes_per_sec: 1024000,
     network_rx_bytes_per_sec: 2048000,
+    last_seen_timestamp: mockNow - 5,
     last_seen: '5s ago',
     kubelet_version: 'v1.28.0'
   },
@@ -35,6 +38,7 @@ export const mockNodes: Node[] = [
     disk_percent: 58.7,
     network_tx_bytes_per_sec: 512000,
     network_rx_bytes_per_sec: 1024000,
+    last_seen_timestamp: mockNow - 3,
     last_seen: '3s ago',
     kubelet_version: 'v1.28.0'
   },
@@ -53,6 +57,7 @@ export const mockNodes: Node[] = [
     disk_percent: 71.2,
     network_tx_bytes_per_sec: 768000,
     network_rx_bytes_per_sec: 1536000,
+    last_seen_timestamp: mockNow - 7,
     last_seen: '7s ago',
     kubelet_version: 'v1.27.5'
   },
@@ -71,6 +76,7 @@ export const mockNodes: Node[] = [
     disk_percent: 48.9,
     network_tx_bytes_per_sec: 2048000,
     network_rx_bytes_per_sec: 4096000,
+    last_seen_timestamp: mockNow - 2,
     last_seen: '2s ago',
     kubelet_version: 'v1.28.0'
   },
@@ -89,6 +95,7 @@ export const mockNodes: Node[] = [
     disk_percent: 65.4,
     network_tx_bytes_per_sec: 1536000,
     network_rx_bytes_per_sec: 3072000,
+    last_seen_timestamp: mockNow - 4,
     last_seen: '4s ago',
     kubelet_version: 'v1.27.5'
   },
@@ -107,6 +114,7 @@ export const mockNodes: Node[] = [
     disk_percent: 52.1,
     network_tx_bytes_per_sec: 896000,
     network_rx_bytes_per_sec: 1792000,
+    last_seen_timestamp: mockNow - 6,
     last_seen: '6s ago',
     kubelet_version: 'v1.28.0'
   },
@@ -125,6 +133,7 @@ export const mockNodes: Node[] = [
     disk_percent: 78.5,
     network_tx_bytes_per_sec: 256000,
     network_rx_bytes_per_sec: 512000,
+    last_seen_timestamp: mockNow - 45,
     last_seen: '45s ago',
     kubelet_version: 'v1.27.5'
   }
@@ -240,4 +249,3 @@ export const mockStats: ClusterStats = {
   total_connections: 8,
   timestamp: new Date().toISOString()
 };
-

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,6 +13,7 @@ export interface Node {
   disk_percent?: number;
   network_tx_bytes_per_sec?: number;
   network_rx_bytes_per_sec?: number;
+  last_seen_timestamp?: number;
   last_seen: string;
   kubelet_version?: string;
 }


### PR DESCRIPTION
## Summary\n- prevent SVG defs growth and reduce map redraws/animation load\n- add last_seen_timestamp and remove 1s sidebar ticker\n- cap/dedupe connections server-side and sample latency targets in agent\n- document new performance-related env vars\n\n## Testing\n- not run (manual)