### PR TITLE
fix: remove deprecated buildx install option

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -54,8 +54,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          install: true
 
       - name: Determine registry host
         id: registry


### PR DESCRIPTION
## Summary

Fixes the deprecation warning in the `build-and-push` job:

> Input 'install' has been deprecated with message: "docker buildx install" command is deprecated and will be removed in a future release, use BUILDX_BUILDER environment variable instead

## Changes

- Removes the `install: true` option from `docker/setup-buildx-action@v3` in `.github/workflows/build-and-publish.yml`

## Details

The `install` input in `docker/setup-buildx-action` has been deprecated. The action now handles builder selection automatically via the `BUILDX_BUILDER` environment variable, which `docker/build-push-action` uses automatically.

This means we no longer need to explicitly set `install: true` - the default behavior handles everything correctly.