### PR TITLE
perf(frontend): cap connection rendering and avoid heavy animation by default

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -101,6 +101,29 @@
   transform: scale(1.1);
 }
 
+.perf-toggle {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 0.9rem;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.perf-toggle:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(1.06);
+}
+
+.perf-toggle.active {
+  background: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
+}
+
 .error-banner {
   background-color: #f44336;
   color: white;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -101,29 +101,6 @@
   transform: scale(1.1);
 }
 
-.perf-toggle {
-  background: rgba(255, 255, 255, 0.2);
-  border: none;
-  border-radius: 8px;
-  padding: 0.5rem 0.9rem;
-  font-size: 1.1rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.perf-toggle:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: scale(1.06);
-}
-
-.perf-toggle.active {
-  background: rgba(255, 255, 255, 0.35);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
-}
-
 .error-banner {
   background-color: #f44336;
   color: white;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ function App() {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [stats, setStats] = useState<ClusterStats | null>(null);
   const [connections, setConnections] = useState<Connection[]>([]);
+  const [connectionsTotal, setConnectionsTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selection, setSelection] = useState<{ id: string; token: number } | null>(null);
@@ -132,6 +133,7 @@ function App() {
 
       setConnections(prevConnections => {
         const newConnections = connectionsResponse.data;
+        setConnectionsTotal(newConnections.length);
         // Quick comparison: check length
         if (prevConnections.length !== newConnections.length) return newConnections;
         
@@ -322,6 +324,7 @@ function App() {
             connections={connections}
             darkMode={darkMode}
             performanceMode={performanceMode}
+            connectionsTotal={connectionsTotal}
             selectedNodeId={selection?.id || null}
             selectionToken={selection?.token || 0}
             onNodeSelect={handleNodeSelect}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,12 @@ function App() {
     const saved = localStorage.getItem('darkMode');
     return saved !== null ? saved === 'true' : false; // Default to light mode
   });
+
+  // Performance mode to reduce CPU usage
+  const [performanceMode, setPerformanceMode] = useState(() => {
+    const saved = localStorage.getItem('performanceMode');
+    return saved !== null ? saved === 'true' : false;
+  });
   
   // Sidebar visibility for mobile - start open on desktop, closed on mobile
   const [sidebarOpen, setSidebarOpen] = useState(() => {
@@ -50,6 +56,11 @@ function App() {
   useEffect(() => {
     localStorage.setItem('darkMode', darkMode.toString());
   }, [darkMode]);
+
+  // Save performance preference when it changes
+  useEffect(() => {
+    localStorage.setItem('performanceMode', performanceMode.toString());
+  }, [performanceMode]);
 
   const fetchData = async () => {
     // Use mock data if enabled or if aggregator is unavailable
@@ -264,6 +275,14 @@ function App() {
             <h1>Dunder Mifflin</h1>
           </div>
           <div className="header-right">
+            <button
+              className={`perf-toggle ${performanceMode ? 'active' : ''}`}
+              onClick={() => setPerformanceMode(!performanceMode)}
+              aria-label="Toggle performance mode"
+              title={performanceMode ? 'Performance mode: on' : 'Performance mode: off'}
+            >
+              ⚡
+            </button>
             <button 
               className="theme-toggle"
               onClick={() => setDarkMode(!darkMode)}
@@ -302,6 +321,7 @@ function App() {
             nodes={nodes}
             connections={connections}
             darkMode={darkMode}
+            performanceMode={performanceMode}
             selectedNodeId={selection?.id || null}
             selectionToken={selection?.token || 0}
             onNodeSelect={handleNodeSelect}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,11 +31,6 @@ function App() {
     return saved !== null ? saved === 'true' : false; // Default to light mode
   });
 
-  // Performance mode to reduce CPU usage
-  const [performanceMode, setPerformanceMode] = useState(() => {
-    const saved = localStorage.getItem('performanceMode');
-    return saved !== null ? saved === 'true' : false;
-  });
   
   // Sidebar visibility for mobile - start open on desktop, closed on mobile
   const [sidebarOpen, setSidebarOpen] = useState(() => {
@@ -58,10 +53,6 @@ function App() {
     localStorage.setItem('darkMode', darkMode.toString());
   }, [darkMode]);
 
-  // Save performance preference when it changes
-  useEffect(() => {
-    localStorage.setItem('performanceMode', performanceMode.toString());
-  }, [performanceMode]);
 
   const fetchData = async () => {
     // Use mock data if enabled or if aggregator is unavailable
@@ -277,14 +268,6 @@ function App() {
             <h1>Dunder Mifflin</h1>
           </div>
           <div className="header-right">
-            <button
-              className={`perf-toggle ${performanceMode ? 'active' : ''}`}
-              onClick={() => setPerformanceMode(!performanceMode)}
-              aria-label="Toggle performance mode"
-              title={performanceMode ? 'Performance mode: on' : 'Performance mode: off'}
-            >
-              ⚡
-            </button>
             <button 
               className="theme-toggle"
               onClick={() => setDarkMode(!darkMode)}
@@ -323,7 +306,6 @@ function App() {
             nodes={nodes}
             connections={connections}
             darkMode={darkMode}
-            performanceMode={performanceMode}
             connectionsTotal={connectionsTotal}
             selectedNodeId={selection?.id || null}
             selectionToken={selection?.token || 0}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,7 +30,6 @@ function App() {
     const saved = localStorage.getItem('darkMode');
     return saved !== null ? saved === 'true' : false; // Default to light mode
   });
-
   
   // Sidebar visibility for mobile - start open on desktop, closed on mobile
   const [sidebarOpen, setSidebarOpen] = useState(() => {
@@ -52,7 +51,6 @@ function App() {
   useEffect(() => {
     localStorage.setItem('darkMode', darkMode.toString());
   }, [darkMode]);
-
 
   const fetchData = async () => {
     // Use mock data if enabled or if aggregator is unavailable

--- a/frontend/src/components/FlatMap.css
+++ b/frontend/src/components/FlatMap.css
@@ -30,6 +30,31 @@
   overflow: hidden;
 }
 
+.connection-cap-indicator {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  padding: 0.4rem 0.65rem;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  z-index: 2;
+  pointer-events: none;
+}
+
+.connection-cap-indicator.dark {
+  background: rgba(6, 10, 24, 0.85);
+  color: #e7ebff;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.connection-cap-indicator.light {
+  background: rgba(255, 255, 255, 0.85);
+  color: #1a1a1a;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
 .flat-map-svg {
   width: 100%;
   height: 100%;
@@ -147,4 +172,3 @@
 .arc-tooltip__row strong {
   font-weight: 600;
 }
-

--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -32,6 +32,7 @@ interface FlatMapConnectionDatum {
 }
 
 const MAX_RENDERED_CONNECTIONS = 150;
+// Animation only applies when the rendered connection count stays below this ceiling.
 const MAX_ANIMATED_CONNECTIONS = 200;
 
 const getCharacterImage = (nodeName: string): string => {

--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { geoMercator, geoPath } from 'd3-geo';
-import { select } from 'd3-selection';
+import { select, type Selection } from 'd3-selection';
 import { zoom as d3Zoom, zoomIdentity, ZoomTransform } from 'd3-zoom';
 import { feature } from 'topojson-client';
 import countriesTopo from 'world-atlas/countries-110m.json';
@@ -628,8 +628,13 @@ const FlatMap: React.FC<FlatMapProps> = ({
       const forwardGradientId = `gradient-forward-${index}`;
       const reverseGradientId = `gradient-reverse-${index}`;
 
-      let forwardFlow: ReturnType<typeof select>;
-      let reverseFlow: ReturnType<typeof select> | null = null;
+      let forwardFlow: Selection<SVGPathElement, unknown, null, undefined>;
+      let reverseFlow: Selection<SVGPathElement, unknown, null, undefined> | null = null;
+
+      // Group for hover effects
+      const lineGroup = connectionGroup.append('g')
+        .attr('class', 'connection-line-group')
+        .attr('data-connection-index', index);
 
       if (!useSimpleLines) {
         // Forward flow gradient (source to target) - aligned along the line
@@ -707,7 +712,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
           .attr('class', 'gradient-stop-reverse-4');
 
         // Single line with forward gradient
-        forwardFlow = connectionGroup
+        forwardFlow = lineGroup
           .append('path')
           .attr('class', 'connection-line-flow-forward')
           .attr('d', `M ${start[0]},${start[1]} L ${end[0]},${end[1]}`)
@@ -717,7 +722,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
           .style('cursor', 'pointer');
 
         // Single line with reverse gradient
-        reverseFlow = connectionGroup
+        reverseFlow = lineGroup
           .append('path')
           .attr('class', 'connection-line-flow-reverse')
           .attr('d', `M ${start[0]},${start[1]} L ${end[0]},${end[1]}`)
@@ -726,7 +731,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
           .attr('fill', 'none')
           .style('cursor', 'pointer');
       } else {
-        forwardFlow = connectionGroup
+        forwardFlow = lineGroup
           .append('path')
           .attr('class', 'connection-line-flow-forward')
           .attr('d', `M ${start[0]},${start[1]} L ${end[0]},${end[1]}`)
@@ -734,16 +739,6 @@ const FlatMap: React.FC<FlatMapProps> = ({
           .attr('stroke-width', 1.2)
           .attr('fill', 'none')
           .style('cursor', 'pointer');
-      }
-
-      // Group for hover effects
-      const lineGroup = connectionGroup.append('g')
-        .attr('class', 'connection-line-group')
-        .attr('data-connection-index', index);
-      
-      lineGroup.node()?.appendChild(forwardFlow.node()!);
-      if (reverseFlow) {
-        lineGroup.node()?.appendChild(reverseFlow.node()!);
       }
 
       lineGroup

--- a/frontend/src/components/FlatMap.tsx
+++ b/frontend/src/components/FlatMap.tsx
@@ -306,7 +306,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
       return;
     }
 
-    if (flatMapConnections.length > MAX_ANIMATED_CONNECTIONS) {
+    if (totalConnections > MAX_ANIMATED_CONNECTIONS) {
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = undefined;
@@ -405,7 +405,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
       }
       gradientStopsRef.current = null;
     };
-  }, [projection, flatMapConnections.length]);
+  }, [projection, flatMapConnections.length, totalConnections]);
 
   // Pause animation when tab is hidden to save CPU/memory
   useEffect(() => {
@@ -616,7 +616,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
     }
     defs.selectAll('linearGradient.connection-gradient').remove();
     
-    const useSimpleLines = flatMapConnections.length > MAX_ANIMATED_CONNECTIONS;
+    const useSimpleLines = totalConnections > MAX_ANIMATED_CONNECTIONS;
 
     flatMapConnections.forEach((conn, index) => {
       const start = projection([conn.startLng, conn.startLat]);
@@ -877,7 +877,7 @@ const FlatMap: React.FC<FlatMapProps> = ({
         .attr('rx', 8)
         .attr('ry', 8);
     }
-  }, [path, projection, mapSize, countryPolygons, flatMapConnections, nodesWithLocation, selectedNodeId, darkMode, onNodeSelect]);
+  }, [path, projection, mapSize, countryPolygons, flatMapConnections, nodesWithLocation, selectedNodeId, darkMode, onNodeSelect, totalConnections]);
 
   const handleMapClick = useCallback((event: React.MouseEvent) => {
     const target = event.target as Element;


### PR DESCRIPTION
## Summary\n- apply performance safeguards by default (no toggle)\n- cap rendered connections to 150, prioritizing lowest latency\n- skip gradient animation when connection count is high; render simple lines instead\n- show a small indicator when the connection cap is applied\n\n## Testing\n- not run (manual)