### PR TITLE
fix: use local character images instead of UI Avatars for node icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19849,6 +19849,7 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20451,6 +20452,7 @@
       "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",

--- a/frontend/src/components/DeckGLMap.tsx
+++ b/frontend/src/components/DeckGLMap.tsx
@@ -54,10 +54,12 @@ const MAP_STYLES = {
 
 const MAX_RENDERED_CONNECTIONS = 200;
 
-// Maroon border color for node icons (used in data URL)
-const MAROON_COLOR = '#800020';
+// Border colors for node icons - black with white outline for visibility in both modes
+const BORDER_FILL_COLOR = '#000000';
+const BORDER_OUTLINE_COLOR = '#FFFFFF';
+const BORDER_OUTLINE_WIDTH = 6;
 
-// Create a data URL for a solid maroon square (used as border background)
+// Create a data URL for a black square with white outline (visible in both light and dark modes)
 const createSquareBorderIcon = (): string => {
   const size = 128;
   const canvas = document.createElement('canvas');
@@ -65,8 +67,12 @@ const createSquareBorderIcon = (): string => {
   canvas.height = size;
   const ctx = canvas.getContext('2d');
   if (ctx) {
-    ctx.fillStyle = MAROON_COLOR;
+    // Draw white outline first (larger square)
+    ctx.fillStyle = BORDER_OUTLINE_COLOR;
     ctx.fillRect(0, 0, size, size);
+    // Draw black fill on top (smaller square, leaving white border)
+    ctx.fillStyle = BORDER_FILL_COLOR;
+    ctx.fillRect(BORDER_OUTLINE_WIDTH, BORDER_OUTLINE_WIDTH, size - BORDER_OUTLINE_WIDTH * 2, size - BORDER_OUTLINE_WIDTH * 2);
   }
   return canvas.toDataURL('image/png');
 };
@@ -224,7 +230,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
         }
       },
     }),
-    // Node border layer (maroon square behind icons)
+    // Node border layer (black square with white outline, visible in both light and dark modes)
     new IconLayer<NodeDatum>({
       id: 'nodes-border',
       data: nodeData,

--- a/frontend/src/components/DeckGLMap.tsx
+++ b/frontend/src/components/DeckGLMap.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Map as ReactMapGL } from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
-import { ArcLayer, IconLayer } from '@deck.gl/layers';
+import { ArcLayer, IconLayer, ScatterplotLayer } from '@deck.gl/layers';
 import { FlyToInterpolator } from '@deck.gl/core';
 import type { PickingInfo } from '@deck.gl/core';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -53,6 +53,9 @@ const MAP_STYLES = {
 };
 
 const MAX_RENDERED_CONNECTIONS = 200;
+
+// Maroon border color for node icons
+const NODE_BORDER_COLOR: [number, number, number, number] = [128, 0, 32, 255];
 
 // Initial view state centered on US with global view
 const INITIAL_VIEW_STATE: ViewState = {
@@ -198,6 +201,18 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
         }
       },
     }),
+    // Node border layer (maroon ring behind icons)
+    new ScatterplotLayer<NodeDatum>({
+      id: 'nodes-border',
+      data: nodeData,
+      getPosition: (d: NodeDatum) => d.coordinates,
+      getRadius: (d: NodeDatum) => (d.isSelected ? 30 : 24),
+      getFillColor: NODE_BORDER_COLOR,
+      radiusUnits: 'pixels',
+      radiusMinPixels: 18,
+      radiusMaxPixels: 36,
+      pickable: false,
+    }),
     // Nodes icon layer
     new IconLayer<NodeDatum>({
       id: 'nodes-icon',
@@ -209,7 +224,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
         height: 128,
         anchorY: 64,
       }),
-      getSize: (d: NodeDatum) => (d.isSelected ? 56 : 44),
+      getSize: (d: NodeDatum) => (d.isSelected ? 52 : 40),
       pickable: true,
       onClick: (info: PickingInfo<NodeDatum>) => {
         if (info.object) {
@@ -230,8 +245,8 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
       },
       sizeScale: 1,
       sizeUnits: 'pixels',
-      sizeMinPixels: 32,
-      sizeMaxPixels: 64,
+      sizeMinPixels: 28,
+      sizeMaxPixels: 60,
     }),
   ], [arcData, nodeData, onNodeSelect, hoveredArc]);
 

--- a/frontend/src/utils/mapUtils.test.ts
+++ b/frontend/src/utils/mapUtils.test.ts
@@ -79,33 +79,38 @@ describe('mapUtils', () => {
   });
 
   describe('getAvatarUrl', () => {
-    it('should generate correct URL for known characters', () => {
-      expect(getAvatarUrl('michael-1')).toBe(
-        'https://ui-avatars.com/api/?name=Michael+Scott&size=128&background=667eea&color=fff&bold=true&rounded=true'
-      );
-      expect(getAvatarUrl('jim-2')).toBe(
-        'https://ui-avatars.com/api/?name=Jim+Halpert&size=128&background=4285F4&color=fff&bold=true&rounded=true'
-      );
-      expect(getAvatarUrl('dwight-3')).toBe(
-        'https://ui-avatars.com/api/?name=Dwight+Schrute&size=128&background=FFC107&color=fff&bold=true&rounded=true'
-      );
+    it('should return local image path for known characters', () => {
+      expect(getAvatarUrl('michael-1')).toBe('/characters/michael.png');
+      expect(getAvatarUrl('jim-2')).toBe('/characters/jim.png');
+      expect(getAvatarUrl('dwight-3')).toBe('/characters/dwight.png');
+      expect(getAvatarUrl('angela-4')).toBe('/characters/angela.png');
+      expect(getAvatarUrl('stanley-5')).toBe('/characters/stanley.png');
+      expect(getAvatarUrl('phyllis-6')).toBe('/characters/phyllis.png');
+      expect(getAvatarUrl('toby-7')).toBe('/characters/toby.png');
+      expect(getAvatarUrl('pam-8')).toBe('/characters/pam.png');
     });
 
-    it('should use default color for unknown characters', () => {
+    it('should fall back to UI Avatars for unknown characters', () => {
       const url = getAvatarUrl('unknown-node');
+      expect(url).toContain('https://ui-avatars.com/api/');
       expect(url).toContain('background=607D8B');
       expect(url).toContain('name=unknown');
     });
 
-    it('should handle uppercase node names', () => {
-      expect(getAvatarUrl('MICHAEL-1')).toBe(
-        'https://ui-avatars.com/api/?name=Michael+Scott&size=128&background=667eea&color=fff&bold=true&rounded=true'
-      );
+    it('should handle uppercase node names for known characters', () => {
+      expect(getAvatarUrl('MICHAEL-1')).toBe('/characters/michael.png');
+      expect(getAvatarUrl('JIM-2')).toBe('/characters/jim.png');
     });
 
     it('should handle node names with multiple hyphens', () => {
-      expect(getAvatarUrl('jim-halpert-office')).toBe(
-        'https://ui-avatars.com/api/?name=Jim+Halpert&size=128&background=4285F4&color=fff&bold=true&rounded=true'
+      expect(getAvatarUrl('jim-halpert-office')).toBe('/characters/jim.png');
+      expect(getAvatarUrl('dwight-schrute-farm')).toBe('/characters/dwight.png');
+    });
+
+    it('should generate UI Avatars URL with correct parameters for unknown characters', () => {
+      const url = getAvatarUrl('creed-bratton-1');
+      expect(url).toBe(
+        'https://ui-avatars.com/api/?name=creed&size=128&background=607D8B&color=fff&bold=true&rounded=true'
       );
     });
   });

--- a/frontend/src/utils/mapUtils.ts
+++ b/frontend/src/utils/mapUtils.ts
@@ -33,7 +33,21 @@ export const getLatencyQuality = (latency: number): string => {
 };
 
 /**
- * Character name to display name mapping
+ * Characters with available images in public/characters/
+ */
+const AVAILABLE_CHARACTERS = new Set([
+  'michael',
+  'jim',
+  'dwight',
+  'angela',
+  'stanley',
+  'phyllis',
+  'toby',
+  'pam',
+]);
+
+/**
+ * Character name to display name mapping (fallback for UI Avatars)
  */
 const CHARACTER_NAMES: Record<string, string> = {
   michael: 'Michael+Scott',
@@ -43,10 +57,11 @@ const CHARACTER_NAMES: Record<string, string> = {
   stanley: 'Stanley+Hudson',
   phyllis: 'Phyllis+Vance',
   toby: 'Toby+Flenderson',
+  pam: 'Pam+Beesly',
 };
 
 /**
- * Character name to avatar background color mapping
+ * Character name to avatar background color mapping (fallback for UI Avatars)
  */
 const CHARACTER_COLORS: Record<string, string> = {
   michael: '667eea',
@@ -56,6 +71,7 @@ const CHARACTER_COLORS: Record<string, string> = {
   stanley: 'ff9800',
   phyllis: '4caf50',
   toby: '795548',
+  pam: 'e91e63',
 };
 
 /**
@@ -64,10 +80,18 @@ const CHARACTER_COLORS: Record<string, string> = {
 const DEFAULT_COLOR = '607D8B';
 
 /**
- * Generates UI Avatars URL for a node based on character name
+ * Returns the avatar URL for a node - uses local character images if available,
+ * falls back to UI Avatars for unknown characters
  */
 export const getAvatarUrl = (nodeName: string): string => {
   const character = nodeName.split('-')[0].toLowerCase();
+  
+  // Use local character image if available
+  if (AVAILABLE_CHARACTERS.has(character)) {
+    return `/characters/${character}.png`;
+  }
+  
+  // Fallback to UI Avatars for unknown characters
   const name = CHARACTER_NAMES[character] || character;
   const color = CHARACTER_COLORS[character] || DEFAULT_COLOR;
   return `https://ui-avatars.com/api/?name=${name}&size=128&background=${color}&color=fff&bold=true&rounded=true`;


### PR DESCRIPTION
## Summary

Fixes the node icons to display actual character images instead of initials.

### Changes

- Updated `getAvatarUrl()` in `mapUtils.ts` to use local character images from `/characters/*.png` for known characters
- Falls back to UI Avatars for unknown characters
- Added `pam` to the list of available characters
- Updated tests to reflect the new behavior

### Before
Node icons showed initials (e.g., "MS" for Michael Scott) using UI Avatars.

### After  
Node icons show actual character images from `public/characters/`.