### PR TITLE
feat: add extended node metrics (temp, CPU freq, uptime, load, swap)

### DIFF
--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -233,6 +233,30 @@ class NodeData(BaseModel):
     network_rx_bytes_per_sec: Optional[float] = None
     connections: Optional[List[Connection]] = None
     timestamp: float = Field(default_factory=time.time)
+    # Extended metrics
+    cpu_temp_celsius: Optional[float] = None
+    temp_critical: Optional[float] = None
+    fan_rpm: Optional[int] = None
+    cpu_freq_mhz: Optional[float] = None
+    cpu_freq_max_mhz: Optional[float] = None
+    uptime_seconds: Optional[float] = None
+    load_avg_1m: Optional[float] = None
+    load_avg_5m: Optional[float] = None
+    load_avg_15m: Optional[float] = None
+    swap_percent: Optional[float] = None
+    swap_total_bytes: Optional[int] = None
+    swap_used_bytes: Optional[int] = None
+    memory_total_bytes: Optional[int] = None
+    memory_available_bytes: Optional[int] = None
+    disk_read_bytes_per_sec: Optional[float] = None
+    disk_write_bytes_per_sec: Optional[float] = None
+    network_packets_sent: Optional[int] = None
+    network_packets_recv: Optional[int] = None
+    network_errin: Optional[int] = None
+    network_errout: Optional[int] = None
+    network_dropin: Optional[int] = None
+    network_dropout: Optional[int] = None
+    process_count: Optional[int] = None
 
 
 class NodeStatus(BaseModel):
@@ -254,6 +278,26 @@ class NodeStatus(BaseModel):
     last_seen_timestamp: float
     last_seen: str
     kubelet_version: Optional[str] = None
+    # Extended metrics
+    cpu_temp_celsius: Optional[float] = None
+    temp_critical: Optional[float] = None
+    fan_rpm: Optional[int] = None
+    cpu_freq_mhz: Optional[float] = None
+    cpu_freq_max_mhz: Optional[float] = None
+    uptime_seconds: Optional[float] = None
+    load_avg_1m: Optional[float] = None
+    load_avg_5m: Optional[float] = None
+    load_avg_15m: Optional[float] = None
+    swap_percent: Optional[float] = None
+    memory_total_bytes: Optional[int] = None
+    memory_available_bytes: Optional[int] = None
+    disk_read_bytes_per_sec: Optional[float] = None
+    disk_write_bytes_per_sec: Optional[float] = None
+    network_errin: Optional[int] = None
+    network_errout: Optional[int] = None
+    network_dropin: Optional[int] = None
+    network_dropout: Optional[int] = None
+    process_count: Optional[int] = None
 
 
 @app.get("/")
@@ -376,7 +420,27 @@ async def get_all_nodes():
                 network_rx_bytes_per_sec=node_data.get('network_rx_bytes_per_sec'),
                 last_seen_timestamp=last_seen_timestamp,
                 last_seen=last_seen,
-                kubelet_version=node_data.get('kubelet_version')
+                kubelet_version=node_data.get('kubelet_version'),
+                # Extended metrics
+                cpu_temp_celsius=node_data.get('cpu_temp_celsius'),
+                temp_critical=node_data.get('temp_critical'),
+                fan_rpm=node_data.get('fan_rpm'),
+                cpu_freq_mhz=node_data.get('cpu_freq_mhz'),
+                cpu_freq_max_mhz=node_data.get('cpu_freq_max_mhz'),
+                uptime_seconds=node_data.get('uptime_seconds'),
+                load_avg_1m=node_data.get('load_avg_1m'),
+                load_avg_5m=node_data.get('load_avg_5m'),
+                load_avg_15m=node_data.get('load_avg_15m'),
+                swap_percent=node_data.get('swap_percent'),
+                memory_total_bytes=node_data.get('memory_total_bytes'),
+                memory_available_bytes=node_data.get('memory_available_bytes'),
+                disk_read_bytes_per_sec=node_data.get('disk_read_bytes_per_sec'),
+                disk_write_bytes_per_sec=node_data.get('disk_write_bytes_per_sec'),
+                network_errin=node_data.get('network_errin'),
+                network_errout=node_data.get('network_errout'),
+                network_dropin=node_data.get('network_dropin'),
+                network_dropout=node_data.get('network_dropout'),
+                process_count=node_data.get('process_count'),
             ))
         
         return nodes_status

--- a/frontend/src/components/StatsPanel.css
+++ b/frontend/src/components/StatsPanel.css
@@ -703,6 +703,252 @@
   color: #333;
 }
 
+/* ===========================================
+   Metrics Box - Unified Card Layout
+   =========================================== */
+.metrics-box {
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.stats-panel.dark .metrics-box {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.stats-panel.light .metrics-box {
+  background: #f8f9fa;
+  border: 1px solid #e8e8e8;
+}
+
+.metrics-box-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid;
+}
+
+.stats-panel.dark .metrics-box-header {
+  background: rgba(255, 255, 255, 0.03);
+  color: #888;
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+.stats-panel.light .metrics-box-header {
+  background: #f0f0f0;
+  color: #666;
+  border-bottom-color: #e0e0e0;
+}
+
+/* Metrics Grid Layout */
+.metrics-box-grid {
+  display: grid;
+  gap: 0;
+}
+
+.metrics-box-grid.cols-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.metrics-box-grid.cols-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+/* Individual Metric Cells */
+.metric-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+}
+
+.metric-cell:last-child {
+  border-right: none;
+}
+
+.stats-panel.dark .metric-cell {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.stats-panel.light .metric-cell {
+  border-color: #e8e8e8;
+}
+
+/* Remove bottom border from last row */
+.metrics-box-grid.cols-3 .metric-cell:nth-child(n+1):nth-last-child(-n+3),
+.metrics-box-grid.cols-3 .metric-cell:nth-child(n+1):nth-last-child(-n+3) ~ .metric-cell,
+.metrics-box-grid.cols-4 .metric-cell:nth-child(n+1):nth-last-child(-n+4),
+.metrics-box-grid.cols-4 .metric-cell:nth-child(n+1):nth-last-child(-n+4) ~ .metric-cell {
+  border-bottom: none;
+}
+
+.metric-cell-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.stats-panel.dark .metric-cell-value {
+  color: #fff;
+}
+
+.stats-panel.light .metric-cell-value {
+  color: #333;
+}
+
+.metric-cell-label {
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-top: 0.25rem;
+}
+
+.stats-panel.dark .metric-cell-label {
+  color: #888;
+}
+
+.stats-panel.light .metric-cell-label {
+  color: #777;
+}
+
+/* Metrics Row - for key-value pairs */
+.metrics-box-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid;
+}
+
+.metrics-box-row:last-child {
+  border-bottom: none;
+}
+
+.stats-panel.dark .metrics-box-row {
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+.stats-panel.light .metrics-box-row {
+  border-bottom-color: #e8e8e8;
+}
+
+.metrics-row-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.stats-panel.dark .metrics-row-label {
+  color: #999;
+}
+
+.stats-panel.light .metrics-row-label {
+  color: #666;
+}
+
+.metrics-row-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-panel.dark .metrics-row-value {
+  color: #e0e0e0;
+}
+
+.stats-panel.light .metrics-row-value {
+  color: #333;
+}
+
+.metrics-row-value.code {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+}
+
+.stats-panel.dark .metrics-row-value.code {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.stats-panel.light .metrics-row-value.code {
+  background: #e8e8e8;
+}
+
+/* I/O specific styling */
+.io-row .io-value {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.io-up {
+  color: #4facfe;
+}
+
+.io-down {
+  color: #43e97b;
+}
+
+.warning-row {
+  background: rgba(255, 152, 0, 0.08);
+}
+
+.stats-panel.dark .warning-row {
+  background: rgba(255, 152, 0, 0.12);
+}
+
+/* Temperature color indicators */
+.metric-cell-value.temp-cool {
+  color: #4caf50 !important;
+}
+
+.metric-cell-value.temp-warm {
+  color: #ff9800 !important;
+}
+
+.metric-cell-value.temp-hot {
+  color: #ff5722 !important;
+}
+
+.metric-cell-value.temp-critical {
+  color: #f44336 !important;
+  animation: pulse-warning 1.5s ease-in-out infinite;
+}
+
+/* CPU throttling indicator */
+.metric-cell-value.throttled {
+  color: #ff9800 !important;
+}
+
+/* Swap warning */
+.metric-cell-value.swap-warning {
+  color: #ff9800 !important;
+}
+
+/* Network errors styling */
+.metrics-row-value.network-errors {
+  color: #ff9800 !important;
+  font-size: 0.75rem;
+}
+
+/* Subtle pulse animation for critical values */
+@keyframes pulse-warning {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+/* Legacy support - keep old classes working */
 .node-details-metrics {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -717,53 +963,4 @@
 
 .stats-panel.light .node-details-metrics {
   background: #f8f9fa;
-}
-
-/* Hardware metrics section - allow 4 columns when there are 4 items */
-.node-details-metrics.hardware-metrics {
-  grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
-}
-
-/* Temperature color indicators */
-.node-detail-value.temp-cool {
-  color: #4caf50 !important;
-}
-
-.node-detail-value.temp-warm {
-  color: #ff9800 !important;
-}
-
-.node-detail-value.temp-hot {
-  color: #ff5722 !important;
-}
-
-.node-detail-value.temp-critical {
-  color: #f44336 !important;
-  animation: pulse-warning 1.5s ease-in-out infinite;
-}
-
-/* CPU throttling indicator */
-.node-detail-value.throttled {
-  color: #ff9800 !important;
-}
-
-/* Swap warning */
-.node-detail-value.swap-warning {
-  color: #ff9800 !important;
-}
-
-/* Network errors styling */
-.node-detail-value.network-errors {
-  color: #ff9800 !important;
-  font-size: 0.8rem;
-}
-
-/* Subtle pulse animation for critical values */
-@keyframes pulse-warning {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.7;
-  }
 }

--- a/frontend/src/components/StatsPanel.css
+++ b/frontend/src/components/StatsPanel.css
@@ -718,3 +718,52 @@
 .stats-panel.light .node-details-metrics {
   background: #f8f9fa;
 }
+
+/* Hardware metrics section - allow 4 columns when there are 4 items */
+.node-details-metrics.hardware-metrics {
+  grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
+}
+
+/* Temperature color indicators */
+.node-detail-value.temp-cool {
+  color: #4caf50 !important;
+}
+
+.node-detail-value.temp-warm {
+  color: #ff9800 !important;
+}
+
+.node-detail-value.temp-hot {
+  color: #ff5722 !important;
+}
+
+.node-detail-value.temp-critical {
+  color: #f44336 !important;
+  animation: pulse-warning 1.5s ease-in-out infinite;
+}
+
+/* CPU throttling indicator */
+.node-detail-value.throttled {
+  color: #ff9800 !important;
+}
+
+/* Swap warning */
+.node-detail-value.swap-warning {
+  color: #ff9800 !important;
+}
+
+/* Network errors styling */
+.node-detail-value.network-errors {
+  color: #ff9800 !important;
+  font-size: 0.8rem;
+}
+
+/* Subtle pulse animation for critical values */
+@keyframes pulse-warning {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -187,138 +187,142 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
                 </div>
               )}
 
-              <div className="node-details-metrics">
-                <div className="node-detail-metric">
-                  <span className="node-detail-label">CPU</span>
-                  <span className="node-detail-value">
-                    {selectedNode.cpu_percent != null ? `${selectedNode.cpu_percent.toFixed(1)}%` : '—'}
-                  </span>
-                </div>
-                <div className="node-detail-metric">
-                  <span className="node-detail-label">Memory</span>
-                  <span className="node-detail-value">
-                    {selectedNode.memory_percent != null ? `${selectedNode.memory_percent.toFixed(1)}%` : '—'}
-                  </span>
-                </div>
-                <div className="node-detail-metric">
-                  <span className="node-detail-label">Disk</span>
-                  <span className="node-detail-value">
-                    {selectedNode.disk_percent != null ? `${selectedNode.disk_percent.toFixed(1)}%` : '—'}
-                  </span>
-                </div>
-                {selectedNode.swap_percent != null && selectedNode.swap_percent > 0 && (
-                  <div className="node-detail-metric">
-                    <span className="node-detail-label">Swap</span>
-                    <span className={`node-detail-value ${selectedNode.swap_percent > 50 ? 'swap-warning' : ''}`}>
-                      {selectedNode.swap_percent.toFixed(1)}%
+              {/* System Overview Box */}
+              <div className="metrics-box">
+                <div className="metrics-box-header">System</div>
+                <div className="metrics-box-grid cols-4">
+                  <div className="metric-cell">
+                    <span className="metric-cell-value">
+                      {selectedNode.cpu_percent != null ? `${selectedNode.cpu_percent.toFixed(1)}%` : '—'}
                     </span>
+                    <span className="metric-cell-label">CPU</span>
+                  </div>
+                  <div className="metric-cell">
+                    <span className="metric-cell-value">
+                      {selectedNode.memory_percent != null ? `${selectedNode.memory_percent.toFixed(1)}%` : '—'}
+                    </span>
+                    <span className="metric-cell-label">Memory</span>
+                  </div>
+                  <div className="metric-cell">
+                    <span className="metric-cell-value">
+                      {selectedNode.disk_percent != null ? `${selectedNode.disk_percent.toFixed(1)}%` : '—'}
+                    </span>
+                    <span className="metric-cell-label">Disk</span>
+                  </div>
+                  {selectedNode.swap_percent != null && selectedNode.swap_percent > 0 ? (
+                    <div className="metric-cell">
+                      <span className={`metric-cell-value ${selectedNode.swap_percent > 50 ? 'swap-warning' : ''}`}>
+                        {selectedNode.swap_percent.toFixed(1)}%
+                      </span>
+                      <span className="metric-cell-label">Swap</span>
+                    </div>
+                  ) : (
+                    <div className="metric-cell">
+                      <span className="metric-cell-value">{selectedNode.process_count ?? '—'}</span>
+                      <span className="metric-cell-label">Procs</span>
+                    </div>
+                  )}
+                </div>
+                {selectedNode.load_avg_1m != null && (
+                  <div className="metrics-box-row">
+                    <span className="metrics-row-label">Load</span>
+                    <span className="metrics-row-value">
+                      {selectedNode.load_avg_1m.toFixed(2)} · {selectedNode.load_avg_5m?.toFixed(2) ?? '—'} · {selectedNode.load_avg_15m?.toFixed(2) ?? '—'}
+                    </span>
+                  </div>
+                )}
+                {selectedNode.uptime_seconds != null && (
+                  <div className="metrics-box-row">
+                    <span className="metrics-row-label">Uptime</span>
+                    <span className="metrics-row-value">{formatUptime(selectedNode.uptime_seconds)}</span>
                   </div>
                 )}
               </div>
 
-              {/* Temperature and Hardware Metrics */}
+              {/* Hardware Box - Temperature, Fan, Frequency */}
               {(selectedNode.cpu_temp_celsius != null || selectedNode.fan_rpm != null || selectedNode.cpu_freq_mhz != null) && (
-                <div className="node-details-metrics hardware-metrics">
-                  {selectedNode.cpu_temp_celsius != null && (
-                    <div className="node-detail-metric">
-                      <span className="node-detail-label">🌡️ Temp</span>
-                      <span className={`node-detail-value ${getTempClass(selectedNode.cpu_temp_celsius, selectedNode.temp_critical)}`}>
-                        {selectedNode.cpu_temp_celsius.toFixed(1)}°C
+                <div className="metrics-box hardware">
+                  <div className="metrics-box-header">Hardware</div>
+                  <div className="metrics-box-grid cols-3">
+                    {selectedNode.cpu_temp_celsius != null && (
+                      <div className="metric-cell">
+                        <span className={`metric-cell-value ${getTempClass(selectedNode.cpu_temp_celsius, selectedNode.temp_critical)}`}>
+                          {selectedNode.cpu_temp_celsius.toFixed(0)}°C
+                        </span>
+                        <span className="metric-cell-label">🌡️ Temp</span>
+                      </div>
+                    )}
+                    {selectedNode.fan_rpm != null && (
+                      <div className="metric-cell">
+                        <span className="metric-cell-value">{selectedNode.fan_rpm}</span>
+                        <span className="metric-cell-label">🌀 RPM</span>
+                      </div>
+                    )}
+                    {selectedNode.cpu_freq_mhz != null && (
+                      <div className="metric-cell">
+                        <span className={`metric-cell-value ${isThrottling(selectedNode.cpu_freq_mhz, selectedNode.cpu_freq_max_mhz) ? 'throttled' : ''}`}>
+                          {(selectedNode.cpu_freq_mhz / 1000).toFixed(1)}G{isThrottling(selectedNode.cpu_freq_mhz, selectedNode.cpu_freq_max_mhz) && '⚠️'}
+                        </span>
+                        <span className="metric-cell-label">⚡ Freq</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* I/O Box - Network and Disk */}
+              {(selectedNode.network_tx_bytes_per_sec != null || selectedNode.disk_read_bytes_per_sec != null) && (
+                <div className="metrics-box io">
+                  <div className="metrics-box-header">I/O</div>
+                  {(selectedNode.network_tx_bytes_per_sec != null || selectedNode.network_rx_bytes_per_sec != null) && (
+                    <div className="metrics-box-row io-row">
+                      <span className="metrics-row-label">Net</span>
+                      <span className="metrics-row-value io-value">
+                        <span className="io-up">⬆ {formatBytesPerSecond(selectedNode.network_tx_bytes_per_sec)}</span>
+                        <span className="io-down">⬇ {formatBytesPerSecond(selectedNode.network_rx_bytes_per_sec)}</span>
                       </span>
                     </div>
                   )}
-                  {selectedNode.fan_rpm != null && (
-                    <div className="node-detail-metric">
-                      <span className="node-detail-label">🌀 Fan</span>
-                      <span className="node-detail-value">{selectedNode.fan_rpm} RPM</span>
+                  {(selectedNode.disk_read_bytes_per_sec != null || selectedNode.disk_write_bytes_per_sec != null) && (
+                    <div className="metrics-box-row io-row">
+                      <span className="metrics-row-label">Disk</span>
+                      <span className="metrics-row-value io-value">
+                        <span className="io-up">⬆ {formatBytesPerSecond(selectedNode.disk_write_bytes_per_sec)}</span>
+                        <span className="io-down">⬇ {formatBytesPerSecond(selectedNode.disk_read_bytes_per_sec)}</span>
+                      </span>
                     </div>
                   )}
-                  {selectedNode.cpu_freq_mhz != null && (
-                    <div className="node-detail-metric">
-                      <span className="node-detail-label">⚡ Freq</span>
-                      <span className={`node-detail-value ${isThrottling(selectedNode.cpu_freq_mhz, selectedNode.cpu_freq_max_mhz) ? 'throttled' : ''}`}>
-                        {(selectedNode.cpu_freq_mhz / 1000).toFixed(2)} GHz
-                        {isThrottling(selectedNode.cpu_freq_mhz, selectedNode.cpu_freq_max_mhz) && ' ⚠️'}
+                  {((selectedNode.network_errin != null && selectedNode.network_errin > 0) ||
+                    (selectedNode.network_errout != null && selectedNode.network_errout > 0) ||
+                    (selectedNode.network_dropin != null && selectedNode.network_dropin > 0)) && (
+                    <div className="metrics-box-row io-row warning-row">
+                      <span className="metrics-row-label">⚠️ Errors</span>
+                      <span className="metrics-row-value network-errors">
+                        {selectedNode.network_errin != null && selectedNode.network_errin > 0 && `Err↓${selectedNode.network_errin} `}
+                        {selectedNode.network_errout != null && selectedNode.network_errout > 0 && `Err↑${selectedNode.network_errout} `}
+                        {selectedNode.network_dropin != null && selectedNode.network_dropin > 0 && `Drop↓${selectedNode.network_dropin.toLocaleString()}`}
                       </span>
                     </div>
                   )}
                 </div>
               )}
 
-              {/* Load Average */}
-              {selectedNode.load_avg_1m != null && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Load Avg</span>
-                  <span className="node-detail-value">
-                    {selectedNode.load_avg_1m.toFixed(2)} / {selectedNode.load_avg_5m?.toFixed(2) ?? '—'} / {selectedNode.load_avg_15m?.toFixed(2) ?? '—'}
+              {/* Info Box - Static details */}
+              <div className="metrics-box info">
+                <div className="metrics-box-header">Info</div>
+                <div className="metrics-box-row">
+                  <span className="metrics-row-label">Last seen</span>
+                  <span className="metrics-row-value">
+                    {formatRelativeTime(selectedNode.last_seen_timestamp ?? selectedNode.last_seen)}
                   </span>
                 </div>
-              )}
-
-              {/* Uptime */}
-              {selectedNode.uptime_seconds != null && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Uptime</span>
-                  <span className="node-detail-value">{formatUptime(selectedNode.uptime_seconds)}</span>
-                </div>
-              )}
-
-              {(selectedNode.network_tx_bytes_per_sec != null ||
-                selectedNode.network_rx_bytes_per_sec != null) && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Network</span>
-                  <span className="node-detail-value">
-                    ⬆ {formatBytesPerSecond(selectedNode.network_tx_bytes_per_sec)} · ⬇{' '}
-                    {formatBytesPerSecond(selectedNode.network_rx_bytes_per_sec)}
-                  </span>
-                </div>
-              )}
-
-              {/* Disk I/O */}
-              {(selectedNode.disk_read_bytes_per_sec != null || selectedNode.disk_write_bytes_per_sec != null) && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Disk I/O</span>
-                  <span className="node-detail-value">
-                    ⬆ {formatBytesPerSecond(selectedNode.disk_write_bytes_per_sec)} · ⬇{' '}
-                    {formatBytesPerSecond(selectedNode.disk_read_bytes_per_sec)}
-                  </span>
-                </div>
-              )}
-
-              {/* Network Errors */}
-              {((selectedNode.network_errin != null && selectedNode.network_errin > 0) ||
-                (selectedNode.network_errout != null && selectedNode.network_errout > 0) ||
-                (selectedNode.network_dropin != null && selectedNode.network_dropin > 0)) && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Net Errors</span>
-                  <span className="node-detail-value network-errors">
-                    {selectedNode.network_errin != null && selectedNode.network_errin > 0 && `Err↓${selectedNode.network_errin} `}
-                    {selectedNode.network_errout != null && selectedNode.network_errout > 0 && `Err↑${selectedNode.network_errout} `}
-                    {selectedNode.network_dropin != null && selectedNode.network_dropin > 0 && `Drop↓${selectedNode.network_dropin.toLocaleString()}`}
-                  </span>
-                </div>
-              )}
-
-              <div className="node-detail-item">
-                <span className="node-detail-label">Last seen</span>
-                <span className="node-detail-value">
-                  {formatRelativeTime(selectedNode.last_seen_timestamp ?? selectedNode.last_seen)}
-                </span>
+                {selectedNode.kubelet_version && (
+                  <div className="metrics-box-row">
+                    <span className="metrics-row-label">Kubelet</span>
+                    <code className="metrics-row-value code">{selectedNode.kubelet_version}</code>
+                  </div>
+                )}
               </div>
-
-              {selectedNode.kubelet_version && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Kubelet</span>
-                  <code className="node-detail-value">{selectedNode.kubelet_version}</code>
-                </div>
-              )}
-
-              {selectedNode.process_count != null && (
-                <div className="node-detail-item">
-                  <span className="node-detail-label">Processes</span>
-                  <span className="node-detail-value">{selectedNode.process_count}</span>
-                </div>
-              )}
             </div>
           </div>
         </>

--- a/frontend/src/mockData.ts
+++ b/frontend/src/mockData.ts
@@ -21,7 +21,24 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 2048000,
     last_seen_timestamp: mockNow - 5,
     last_seen: '5s ago',
-    kubelet_version: 'v1.28.0'
+    kubelet_version: 'v1.28.0',
+    // Extended metrics - RPi 5 with active cooling
+    cpu_temp_celsius: 47.5,
+    temp_critical: 85,
+    fan_rpm: 1120,
+    cpu_freq_mhz: 2400,
+    cpu_freq_max_mhz: 2400,
+    uptime_seconds: 3212343,  // ~37 days
+    load_avg_1m: 0.22,
+    load_avg_5m: 0.25,
+    load_avg_15m: 0.18,
+    swap_percent: 44.5,
+    memory_total_bytes: 8256512000,
+    memory_available_bytes: 4904288000,
+    disk_read_bytes_per_sec: 102400,
+    disk_write_bytes_per_sec: 512000,
+    network_dropin: 5247926,
+    process_count: 592
   },
   {
     name: 'jim-2',
@@ -40,7 +57,20 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 1024000,
     last_seen_timestamp: mockNow - 3,
     last_seen: '3s ago',
-    kubelet_version: 'v1.28.0'
+    kubelet_version: 'v1.28.0',
+    // Extended metrics - Cloud VM (no temp/fan)
+    cpu_freq_mhz: 2200,
+    cpu_freq_max_mhz: 2200,
+    uptime_seconds: 1450885,  // ~17 days
+    load_avg_1m: 0.26,
+    load_avg_5m: 0.31,
+    load_avg_15m: 0.35,
+    swap_percent: 0,
+    memory_total_bytes: 1073741824,
+    memory_available_bytes: 524288000,
+    disk_read_bytes_per_sec: 51200,
+    disk_write_bytes_per_sec: 204800,
+    process_count: 156
   },
   {
     name: 'dwight-3',
@@ -59,7 +89,24 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 1536000,
     last_seen_timestamp: mockNow - 7,
     last_seen: '7s ago',
-    kubelet_version: 'v1.27.5'
+    kubelet_version: 'v1.27.5',
+    // Extended metrics - RPi 4 (passive cooling, warmer)
+    cpu_temp_celsius: 64.3,
+    temp_critical: 110,
+    cpu_freq_mhz: 700,  // Throttled!
+    cpu_freq_max_mhz: 1500,
+    uptime_seconds: 864000,  // 10 days
+    load_avg_1m: 1.85,
+    load_avg_5m: 1.42,
+    load_avg_15m: 1.21,
+    swap_percent: 62.5,  // High swap usage!
+    memory_total_bytes: 4294967296,
+    memory_available_bytes: 1073741824,
+    disk_read_bytes_per_sec: 25600,
+    disk_write_bytes_per_sec: 102400,
+    network_errin: 5,
+    network_dropin: 12345,
+    process_count: 423
   },
   {
     name: 'angela-4',
@@ -78,7 +125,19 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 4096000,
     last_seen_timestamp: mockNow - 2,
     last_seen: '2s ago',
-    kubelet_version: 'v1.28.0'
+    kubelet_version: 'v1.28.0',
+    // Extended metrics - GCP VM
+    cpu_freq_mhz: 2199.998,
+    uptime_seconds: 259200,  // 3 days
+    load_avg_1m: 0.08,
+    load_avg_5m: 0.12,
+    load_avg_15m: 0.10,
+    swap_percent: 0,
+    memory_total_bytes: 2147483648,
+    memory_available_bytes: 1073741824,
+    disk_read_bytes_per_sec: 10240,
+    disk_write_bytes_per_sec: 51200,
+    process_count: 89
   },
   {
     name: 'stanley-5',
@@ -97,7 +156,20 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 3072000,
     last_seen_timestamp: mockNow - 4,
     last_seen: '4s ago',
-    kubelet_version: 'v1.27.5'
+    kubelet_version: 'v1.27.5',
+    // Extended metrics - Oracle ARM
+    cpu_freq_mhz: 2500,
+    cpu_freq_max_mhz: 2500,
+    uptime_seconds: 5184000,  // 60 days
+    load_avg_1m: 0.45,
+    load_avg_5m: 0.52,
+    load_avg_15m: 0.48,
+    swap_percent: 0,
+    memory_total_bytes: 25769803776,
+    memory_available_bytes: 20000000000,
+    disk_read_bytes_per_sec: 204800,
+    disk_write_bytes_per_sec: 1024000,
+    process_count: 1567
   },
   {
     name: 'phyllis-6',
@@ -116,7 +188,23 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 1792000,
     last_seen_timestamp: mockNow - 6,
     last_seen: '6s ago',
-    kubelet_version: 'v1.28.0'
+    kubelet_version: 'v1.28.0',
+    // Extended metrics - RPi 5 cool
+    cpu_temp_celsius: 42.1,
+    temp_critical: 85,
+    fan_rpm: 850,
+    cpu_freq_mhz: 2400,
+    cpu_freq_max_mhz: 2400,
+    uptime_seconds: 172800,  // 2 days
+    load_avg_1m: 0.05,
+    load_avg_5m: 0.08,
+    load_avg_15m: 0.06,
+    swap_percent: 12.3,
+    memory_total_bytes: 8589934592,
+    memory_available_bytes: 6442450944,
+    disk_read_bytes_per_sec: 5120,
+    disk_write_bytes_per_sec: 25600,
+    process_count: 312
   },
   {
     name: 'toby-7',
@@ -135,7 +223,23 @@ export const mockNodes: Node[] = [
     network_rx_bytes_per_sec: 512000,
     last_seen_timestamp: mockNow - 45,
     last_seen: '45s ago',
-    kubelet_version: 'v1.27.5'
+    kubelet_version: 'v1.27.5',
+    // Extended metrics - stressed node
+    cpu_freq_mhz: 1800,
+    cpu_freq_max_mhz: 2200,  // Slight throttling
+    uptime_seconds: 86400,  // 1 day
+    load_avg_1m: 3.25,
+    load_avg_5m: 2.87,
+    load_avg_15m: 2.45,
+    swap_percent: 78.5,  // High swap!
+    memory_total_bytes: 1073741824,
+    memory_available_bytes: 107374182,
+    disk_read_bytes_per_sec: 512000,
+    disk_write_bytes_per_sec: 2048000,
+    network_errin: 15,
+    network_errout: 3,
+    network_dropin: 98765,
+    process_count: 234
   }
 ];
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,6 +16,26 @@ export interface Node {
   last_seen_timestamp?: number;
   last_seen: string;
   kubelet_version?: string;
+  // Extended metrics
+  cpu_temp_celsius?: number;
+  temp_critical?: number;
+  fan_rpm?: number;
+  cpu_freq_mhz?: number;
+  cpu_freq_max_mhz?: number;
+  uptime_seconds?: number;
+  load_avg_1m?: number;
+  load_avg_5m?: number;
+  load_avg_15m?: number;
+  swap_percent?: number;
+  memory_total_bytes?: number;
+  memory_available_bytes?: number;
+  disk_read_bytes_per_sec?: number;
+  disk_write_bytes_per_sec?: number;
+  network_errin?: number;
+  network_errout?: number;
+  network_dropin?: number;
+  network_dropout?: number;
+  process_count?: number;
 }
 
 export interface Connection {


### PR DESCRIPTION
## Summary

This PR adds comprehensive hardware and system metrics to the homelab-map, providing deeper visibility into node health and performance.

## New Metrics

### Hardware Metrics (primarily for Raspberry Pi)
- **🌡️ CPU Temperature** - with color-coded indicators (cool/warm/hot/critical)
- **🌀 Fan Speed** - RPM for Pi 5 active cooling
- **⚡ CPU Frequency** - current/max with throttling detection

### System Metrics (all nodes)
- **⏱️ Uptime** - human-readable format (e.g., "37d 4h")
- **📊 Load Average** - 1m/5m/15m
- **💾 Swap Usage** - with warning indicator when >50%
- **Memory Details** - total/available bytes
- **📀 Disk I/O** - read/write throughput
- **🌐 Network Health** - error and drop counts
- **🔢 Process Count**

## Changes

### Agent (\`agent/agent.py\`)
- New metric collection functions using \`psutil\`
- Temperature and fan via sensors_temperatures() and sensors_fans()
- CPU frequency via cpu_freq()
- System metrics via boot_time, loadavg, swap, memory
- Network health via net_io_counters error/drop stats
- Disk I/O rate calculation

### Aggregator (\`aggregator/main.py\`)
- Extended NodeData and NodeStatus Pydantic models
- Pass through all new metrics to frontend

### Frontend
- Updated types.ts with new Node interface fields
- Extended StatsPanel.tsx with hardware metrics section
- Added CSS for temperature color indicators and throttling warnings

## Availability by Node Type

| Metric | Raspberry Pi | Cloud VMs |
|--------|--------------|-----------|
| Temperature | ✅ | ❌ |
| Fan Speed | ✅ (Pi 5 only) | ❌ |
| CPU Frequency | ✅ | ✅ |
| Uptime | ✅ | ✅ |
| Load Average | ✅ | ✅ |
| Swap | ✅ | ✅ |
| Disk I/O | ✅ | ✅ |
| Network Errors | ✅ | ✅ |