### PR TITLE
feat: add AI-powered quote generation for node characters

### DIFF
--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -7,10 +7,13 @@ Receives data from agents and serves to frontend
 import os
 import time
 import logging
+import hashlib
 from typing import Dict, List, Optional
 from datetime import datetime
+from dataclasses import dataclass
 
 from fastapi import FastAPI, HTTPException
+from openai import OpenAI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -20,6 +23,46 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Initialize OpenAI client (uses OPENAI_API_KEY env var)
+openai_client: Optional[OpenAI] = None
+if os.getenv("OPENAI_API_KEY"):
+    openai_client = OpenAI()
+    logger.info("OpenAI client initialized")
+else:
+    logger.warning("OPENAI_API_KEY not set, quote generation will use fallback quotes")
+
+
+@dataclass
+class QuoteCache:
+    """Cached quote with metadata"""
+    quote: str
+    generated_at: float  # Unix timestamp
+    metrics_hash: str  # Hash of metrics used to generate quote
+
+
+# In-memory quote cache (node_name -> QuoteCache)
+quote_cache: Dict[str, QuoteCache] = {}
+QUOTE_CACHE_TTL_SECONDS = 86400  # 24 hours
+
+# Static fallback quotes for when OpenAI is unavailable
+FALLBACK_QUOTES = {
+    'michael': "I'm not superstitious, but I am a little stitious.",
+    'dwight': "Identity theft is not a joke, Jim! Millions of families suffer every year!",
+    'jim': "Bears. Beets. Battlestar Galactica.",
+    'pam': "There's a lot of beauty in ordinary things. Isn't that kind of the point?",
+    'angela': "I don't have a headache. I'm just preparing.",
+    'kevin': "Why waste time say lot word when few word do trick?",
+    'stanley': "Did I stutter?",
+    'phyllis': "Close your mouth, sweetie. You look like a trout.",
+    'toby': "I hate so much about the things that you choose to be.",
+    'oscar': "Actually...",
+    'creed': "Nobody steals from Creed Bratton and gets away with it.",
+    'meredith': "It's casual day!",
+    'andy': "I'm always thinking one step ahead... like a carpenter that makes stairs.",
+    'ryan': "I'd rather she be alone than with somebody. Is that love?",
+    'kelly': "I talk a lot, so I've learned to tune myself out.",
+}
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -575,6 +618,145 @@ async def get_cluster_stats():
     except Exception as e:
         logger.error(f"Error getting cluster stats: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def _compute_metrics_hash(node_data: dict) -> str:
+    """Compute a hash of key metrics to detect significant changes"""
+    # Round metrics to avoid hash changes from minor fluctuations
+    cpu = round(node_data.get('cpu_percent', 0) / 10) * 10  # Round to nearest 10%
+    mem = round(node_data.get('memory_percent', 0) / 10) * 10
+    uptime_days = int((node_data.get('uptime_seconds', 0) or 0) / 86400)  # Days
+
+    key = f"{cpu}:{mem}:{uptime_days}"
+    return hashlib.md5(key.encode()).hexdigest()[:8]
+
+
+def _format_uptime(seconds: Optional[float]) -> str:
+    """Format uptime in human-readable form"""
+    if not seconds or seconds < 0:
+        return "unknown"
+
+    days = int(seconds / 86400)
+    hours = int((seconds % 86400) / 3600)
+
+    if days > 0:
+        return f"{days} days"
+    return f"{hours} hours"
+
+
+async def _generate_quote(character: str, node_name: str, node_data: dict) -> str:
+    """Generate a quote using OpenAI API"""
+    if not openai_client:
+        return FALLBACK_QUOTES.get(character, "That's what she said.")
+
+    # Build metrics string
+    metrics_parts = [f"Node: {node_name}"]
+
+    if node_data.get('cpu_percent') is not None:
+        metrics_parts.append(f"CPU: {node_data['cpu_percent']:.0f}%")
+
+    if node_data.get('memory_percent') is not None:
+        metrics_parts.append(f"Memory: {node_data['memory_percent']:.0f}%")
+
+    if node_data.get('uptime_seconds'):
+        metrics_parts.append(f"Uptime: {_format_uptime(node_data['uptime_seconds'])}")
+
+    if node_data.get('cpu_temp_celsius') is not None:
+        metrics_parts.append(f"Temperature: {node_data['cpu_temp_celsius']:.0f}°C")
+
+    if node_data.get('load_avg_1m') is not None:
+        metrics_parts.append(f"Load: {node_data['load_avg_1m']:.2f}")
+
+    metrics_str = ", ".join(metrics_parts)
+
+    # Character name mapping for more natural prompts
+    character_names = {
+        'michael': 'Michael Scott',
+        'dwight': 'Dwight Schrute',
+        'jim': 'Jim Halpert',
+        'pam': 'Pam Beesly',
+        'angela': 'Angela Martin',
+        'kevin': 'Kevin Malone',
+        'stanley': 'Stanley Hudson',
+        'phyllis': 'Phyllis Vance',
+        'toby': 'Toby Flenderson',
+        'oscar': 'Oscar Martinez',
+        'creed': 'Creed Bratton',
+        'meredith': 'Meredith Palmer',
+        'andy': 'Andy Bernard',
+        'ryan': 'Ryan Howard',
+        'kelly': 'Kelly Kapoor',
+    }
+
+    full_name = character_names.get(character, character.title())
+
+    prompt = f"""Generate a short, funny quote in the style of {full_name} from The Office (US). Reference these server metrics humorously:
+{metrics_str}
+
+1-2 sentences max. Output only the quote."""
+
+    try:
+        response = openai_client.chat.completions.create(
+            model="gpt-4.1-mini",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=100,
+            temperature=0.8,
+        )
+        quote = response.choices[0].message.content.strip()
+        # Remove surrounding quotes if present
+        if quote.startswith('"') and quote.endswith('"'):
+            quote = quote[1:-1]
+        return quote
+    except Exception as e:
+        logger.error(f"OpenAI API error: {e}")
+        return FALLBACK_QUOTES.get(character, "That's what she said.")
+
+
+@app.get("/api/quote/{node_name}")
+async def get_node_quote(node_name: str):
+    """Get an AI-generated quote for a specific node based on its character"""
+    if node_name not in nodes_data:
+        raise HTTPException(status_code=404, detail=f"Node {node_name} not found")
+
+    node_data = nodes_data[node_name]
+
+    # Extract character name from node_name (e.g., "dwight-pi" -> "dwight")
+    character = node_name.split('-')[0].lower()
+
+    # Check cache
+    current_time = time.time()
+    metrics_hash = _compute_metrics_hash(node_data)
+
+    if node_name in quote_cache:
+        cached = quote_cache[node_name]
+        age = current_time - cached.generated_at
+
+        # Return cached quote if still valid (within TTL and metrics haven't changed significantly)
+        if age < QUOTE_CACHE_TTL_SECONDS and cached.metrics_hash == metrics_hash:
+            return {
+                "node_name": node_name,
+                "character": character,
+                "quote": cached.quote,
+                "cached": True,
+                "cache_age_seconds": int(age),
+            }
+
+    # Generate new quote
+    quote = await _generate_quote(character, node_name, node_data)
+
+    # Cache the quote
+    quote_cache[node_name] = QuoteCache(
+        quote=quote,
+        generated_at=current_time,
+        metrics_hash=metrics_hash,
+    )
+
+    return {
+        "node_name": node_name,
+        "character": character,
+        "quote": quote,
+        "cached": False,
+    }
 
 
 if __name__ == "__main__":

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from dataclasses import dataclass
 
 from fastapi import FastAPI, HTTPException
-from openai import OpenAI
+from openai import AsyncOpenAI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -24,11 +24,11 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize OpenAI client (uses OPENAI_API_KEY env var)
-openai_client: Optional[OpenAI] = None
+# Initialize async OpenAI client (uses OPENAI_API_KEY env var)
+openai_client: Optional[AsyncOpenAI] = None
 if os.getenv("OPENAI_API_KEY"):
-    openai_client = OpenAI()
-    logger.info("OpenAI client initialized")
+    openai_client = AsyncOpenAI()
+    logger.info("AsyncOpenAI client initialized")
 else:
     logger.warning("OPENAI_API_KEY not set, quote generation will use fallback quotes")
 
@@ -696,7 +696,7 @@ async def _generate_quote(character: str, node_name: str, node_data: dict) -> st
 1-2 sentences max. Output only the quote."""
 
     try:
-        response = openai_client.chat.completions.create(
+        response = await openai_client.chat.completions.create(
             model="gpt-4.1-mini",
             messages=[{"role": "user", "content": prompt}],
             max_tokens=100,

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -626,8 +626,11 @@ def _compute_metrics_hash(node_data: dict) -> str:
     cpu = round(node_data.get('cpu_percent', 0) / 10) * 10  # Round to nearest 10%
     mem = round(node_data.get('memory_percent', 0) / 10) * 10
     uptime_days = int((node_data.get('uptime_seconds', 0) or 0) / 86400)  # Days
+    # Include temp and load since they're used in the quote prompt
+    temp = round((node_data.get('cpu_temp_celsius') or 0) / 5) * 5  # Round to nearest 5°C
+    load = round((node_data.get('load_avg_1m') or 0) * 2) / 2  # Round to nearest 0.5
 
-    key = f"{cpu}:{mem}:{uptime_days}"
+    key = f"{cpu}:{mem}:{uptime_days}:{temp}:{load}"
     return hashlib.md5(key.encode()).hexdigest()[:8]
 
 

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -623,9 +623,10 @@ async def get_cluster_stats():
 def _compute_metrics_hash(node_data: dict) -> str:
     """Compute a hash of key metrics to detect significant changes"""
     # Round metrics to avoid hash changes from minor fluctuations
-    cpu = round(node_data.get('cpu_percent', 0) / 10) * 10  # Round to nearest 10%
-    mem = round(node_data.get('memory_percent', 0) / 10) * 10
-    uptime_days = int((node_data.get('uptime_seconds', 0) or 0) / 86400)  # Days
+    # Use `or 0` to handle None values (nodes may have missing metrics)
+    cpu = round((node_data.get('cpu_percent') or 0) / 10) * 10  # Round to nearest 10%
+    mem = round((node_data.get('memory_percent') or 0) / 10) * 10
+    uptime_days = int((node_data.get('uptime_seconds') or 0) / 86400)  # Days
     # Include temp and load since they're used in the quote prompt
     temp = round((node_data.get('cpu_temp_celsius') or 0) / 5) * 5  # Round to nearest 5°C
     load = round((node_data.get('load_avg_1m') or 0) * 2) / 2  # Round to nearest 0.5

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -622,14 +622,14 @@ async def get_cluster_stats():
 
 def _compute_metrics_hash(node_data: dict) -> str:
     """Compute a hash of key metrics to detect significant changes"""
-    # Round metrics to avoid hash changes from minor fluctuations
+    # Use floor division to bucket metrics - avoids cache invalidation on minor changes
     # Use `or 0` to handle None values (nodes may have missing metrics)
-    cpu = round((node_data.get('cpu_percent') or 0) / 10) * 10  # Round to nearest 10%
-    mem = round((node_data.get('memory_percent') or 0) / 10) * 10
+    cpu = int((node_data.get('cpu_percent') or 0) / 10) * 10  # Floor to 10% bucket
+    mem = int((node_data.get('memory_percent') or 0) / 10) * 10
     uptime_days = int((node_data.get('uptime_seconds') or 0) / 86400)  # Days
     # Include temp and load since they're used in the quote prompt
-    temp = round((node_data.get('cpu_temp_celsius') or 0) / 5) * 5  # Round to nearest 5°C
-    load = round((node_data.get('load_avg_1m') or 0) * 2) / 2  # Round to nearest 0.5
+    temp = int((node_data.get('cpu_temp_celsius') or 0) / 5) * 5  # Floor to 5°C bucket
+    load = int((node_data.get('load_avg_1m') or 0) * 2) / 2  # Floor to 0.5 bucket
 
     key = f"{cpu}:{mem}:{uptime_days}:{temp}:{load}"
     return hashlib.md5(key.encode()).hexdigest()[:8]

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -215,6 +215,7 @@ def _cleanup_stale_nodes():
     for node_name in nodes_to_remove:
         del nodes_data[node_name]
         connections_data.pop(node_name, None)
+        quote_cache.pop(node_name, None)  # Prune cached quotes for removed nodes
         # Also remove connections where this node is the target
         for source_node in list(connections_data.keys()):
             connections = connections_data[source_node]

--- a/aggregator/requirements.txt
+++ b/aggregator/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil==2.8.2
 pytest==7.4.3
 pytest-asyncio==0.21.1
 httpx==0.25.2
+openai>=1.0.0

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -570,6 +570,23 @@ def test_compute_metrics_hash_consistency() -> None:
     assert hash1 == hash2
 
 
+def test_compute_metrics_hash_handles_none_values() -> None:
+    """Test that metrics hash handles None values without raising TypeError."""
+    # Node with all None metrics (e.g., newly added or offline node)
+    node_data = {
+        "cpu_percent": None,
+        "memory_percent": None,
+        "uptime_seconds": None,
+        "cpu_temp_celsius": None,
+        "load_avg_1m": None,
+    }
+
+    # Should not raise TypeError
+    result = main._compute_metrics_hash(node_data)
+    assert isinstance(result, str)
+    assert len(result) == 8  # MD5 hex truncated to 8 chars
+
+
 def test_compute_metrics_hash_rounds_values() -> None:
     """Test that small metric changes don't affect hash."""
     # Values within same rounding buckets:

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -572,12 +572,13 @@ def test_compute_metrics_hash_consistency() -> None:
 
 def test_compute_metrics_hash_rounds_values() -> None:
     """Test that small metric changes don't affect hash."""
+    # Both round to 50% CPU, 70% memory (values within same 10% bucket)
     node_data1 = {"cpu_percent": 45.0, "memory_percent": 67.0}
-    node_data2 = {"cpu_percent": 48.0, "memory_percent": 63.0}  # Within rounding
+    node_data2 = {"cpu_percent": 48.0, "memory_percent": 72.0}
 
     hash1 = main._compute_metrics_hash(node_data1)
     hash2 = main._compute_metrics_hash(node_data2)
-    assert hash1 == hash2  # Both round to 50% CPU, 70% memory
+    assert hash1 == hash2
 
 
 def test_format_uptime() -> None:

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -573,7 +573,7 @@ def test_compute_metrics_hash_consistency() -> None:
 def test_compute_metrics_hash_rounds_values() -> None:
     """Test that small metric changes don't affect hash."""
     # Values within same rounding buckets:
-    # CPU: 51-54 -> 50, Memory: 71-74 -> 70, Temp: 41-44 -> 40, Load: 1.1-1.2 -> 1.0
+    # CPU: 51-54 -> 50, Memory: 71-74 -> 70, Temp: 41-42 -> 40, Load: 1.1-1.2 -> 1.0
     node_data1 = {
         "cpu_percent": 51.0,
         "memory_percent": 71.0,
@@ -583,7 +583,7 @@ def test_compute_metrics_hash_rounds_values() -> None:
     node_data2 = {
         "cpu_percent": 54.0,
         "memory_percent": 74.0,
-        "cpu_temp_celsius": 44.0,
+        "cpu_temp_celsius": 42.0,  # 42/5=8.4 rounds to 8, 8*5=40
         "load_avg_1m": 1.2,
     }
 

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -572,9 +572,20 @@ def test_compute_metrics_hash_consistency() -> None:
 
 def test_compute_metrics_hash_rounds_values() -> None:
     """Test that small metric changes don't affect hash."""
-    # Both round to 50% CPU, 70% memory (51-54 -> 50, 71-74 -> 70)
-    node_data1 = {"cpu_percent": 51.0, "memory_percent": 71.0}
-    node_data2 = {"cpu_percent": 54.0, "memory_percent": 74.0}
+    # Values within same rounding buckets:
+    # CPU: 51-54 -> 50, Memory: 71-74 -> 70, Temp: 41-44 -> 40, Load: 1.1-1.2 -> 1.0
+    node_data1 = {
+        "cpu_percent": 51.0,
+        "memory_percent": 71.0,
+        "cpu_temp_celsius": 41.0,
+        "load_avg_1m": 1.1,
+    }
+    node_data2 = {
+        "cpu_percent": 54.0,
+        "memory_percent": 74.0,
+        "cpu_temp_celsius": 44.0,
+        "load_avg_1m": 1.2,
+    }
 
     hash1 = main._compute_metrics_hash(node_data1)
     hash2 = main._compute_metrics_hash(node_data2)

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -572,9 +572,9 @@ def test_compute_metrics_hash_consistency() -> None:
 
 def test_compute_metrics_hash_rounds_values() -> None:
     """Test that small metric changes don't affect hash."""
-    # Both round to 50% CPU, 70% memory (values within same 10% bucket)
-    node_data1 = {"cpu_percent": 45.0, "memory_percent": 67.0}
-    node_data2 = {"cpu_percent": 48.0, "memory_percent": 72.0}
+    # Both round to 50% CPU, 70% memory (51-54 -> 50, 71-74 -> 70)
+    node_data1 = {"cpu_percent": 51.0, "memory_percent": 71.0}
+    node_data2 = {"cpu_percent": 54.0, "memory_percent": 74.0}
 
     hash1 = main._compute_metrics_hash(node_data1)
     hash2 = main._compute_metrics_hash(node_data2)

--- a/aggregator/tests/test_main.py
+++ b/aggregator/tests/test_main.py
@@ -587,10 +587,10 @@ def test_compute_metrics_hash_handles_none_values() -> None:
     assert len(result) == 8  # MD5 hex truncated to 8 chars
 
 
-def test_compute_metrics_hash_rounds_values() -> None:
-    """Test that small metric changes don't affect hash."""
-    # Values within same rounding buckets:
-    # CPU: 51-54 -> 50, Memory: 71-74 -> 70, Temp: 41-42 -> 40, Load: 1.1-1.2 -> 1.0
+def test_compute_metrics_hash_floors_values() -> None:
+    """Test that small metric changes don't affect hash (using floor division)."""
+    # Values within same floor buckets:
+    # CPU: 50-59 -> 50, Memory: 70-79 -> 70, Temp: 40-44 -> 40, Load: 1.0-1.49 -> 1.0
     node_data1 = {
         "cpu_percent": 51.0,
         "memory_percent": 71.0,
@@ -598,10 +598,10 @@ def test_compute_metrics_hash_rounds_values() -> None:
         "load_avg_1m": 1.1,
     }
     node_data2 = {
-        "cpu_percent": 54.0,
-        "memory_percent": 74.0,
-        "cpu_temp_celsius": 42.0,  # 42/5=8.4 rounds to 8, 8*5=40
-        "load_avg_1m": 1.2,
+        "cpu_percent": 58.0,  # Still floors to 50
+        "memory_percent": 78.0,  # Still floors to 70
+        "cpu_temp_celsius": 44.0,  # 44/5=8.8 -> int=8 -> 8*5=40
+        "load_avg_1m": 1.4,  # 1.4*2=2.8 -> int=2 -> 2/2=1.0
     }
 
     hash1 = main._compute_metrics_hash(node_data1)

--- a/frontend/src/components/StatsPanel.css
+++ b/frontend/src/components/StatsPanel.css
@@ -614,6 +614,15 @@
   color: #555;
 }
 
+.node-quote-text.loading {
+  opacity: 0.7;
+}
+
+.quote-loading {
+  font-style: normal;
+  opacity: 0.6;
+}
+
 .stats-panel.dark .node-details-title-text h3 {
   color: #ffffff;
 }

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -127,7 +127,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
     };
 
     fetchQuote();
-  }, [selectedNode?.name]);
+  }, [selectedNode]);
 
   if (!stats) {
     return null;

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,8 +1,11 @@
-import React, { memo } from 'react';
+import React, { memo, useState, useEffect } from 'react';
+import axios from 'axios';
 import { ClusterStats, Node } from '../types';
 import { formatBytesPerSecond } from '../utils/format';
 import { getCharacterFromNodeName, getCharacterImage, getCharacterQuote } from '../utils/characterUtils';
 import './StatsPanel.css';
+
+const AGGREGATOR_URL = process.env.REACT_APP_AGGREGATOR_URL || 'http://localhost:8000';
 
 // Format a timestamp as relative time (e.g., "2s ago", "5m ago")
 const formatRelativeTime = (timestamp: number | string | undefined): string => {
@@ -97,11 +100,38 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
   isOpen = true,
   onClose,
 }) => {
+  const [quote, setQuote] = useState<string | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+
+  const selectedNode = selectedNodeId && showDetails ? nodes.find((node) => node.name === selectedNodeId) : null;
+
+  // Fetch AI-generated quote when node is selected
+  useEffect(() => {
+    if (!selectedNode) {
+      setQuote(null);
+      return;
+    }
+
+    const fetchQuote = async () => {
+      setQuoteLoading(true);
+      try {
+        const response = await axios.get(`${AGGREGATOR_URL}/api/quote/${selectedNode.name}`);
+        setQuote(response.data.quote);
+      } catch (error) {
+        // Fallback to static quote on error
+        console.warn('Failed to fetch AI quote, using fallback:', error);
+        setQuote(getCharacterQuote(getCharacterFromNodeName(selectedNode.name)));
+      } finally {
+        setQuoteLoading(false);
+      }
+    };
+
+    fetchQuote();
+  }, [selectedNode?.name]);
+
   if (!stats) {
     return null;
   }
-
-  const selectedNode = selectedNodeId && showDetails ? nodes.find((node) => node.name === selectedNodeId) : null;
 
   return (
     <div className={`stats-panel ${darkMode ? 'dark' : 'light'} ${isOpen ? 'open' : ''} ${showDetails ? 'showing-details' : ''}`}>
@@ -154,8 +184,12 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
             </div>
             
             <div className="node-quote">
-              <div className="node-quote-text">
-                "{getCharacterQuote(getCharacterFromNodeName(selectedNode.name))}"
+              <div className={`node-quote-text ${quoteLoading ? 'loading' : ''}`}>
+                {quoteLoading ? (
+                  <span className="quote-loading">Generating quote...</span>
+                ) : (
+                  `"${quote || getCharacterQuote(getCharacterFromNodeName(selectedNode.name))}"`
+                )}
               </div>
             </div>
             

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group all non-major npm updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm non-major dependencies"
+    },
+    {
+      "description": "Group all non-major pip updates",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "pip non-major dependencies"
+    },
+    {
+      "description": "Group Docker base image updates",
+      "matchManagers": ["dockerfile"],
+      "groupName": "docker base images"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add OpenAI integration to aggregator using `gpt-4.1-mini` model
- Add `/api/quote/{node_name}` endpoint that generates character-specific quotes based on node metrics
- Implement 24-hour quote caching with automatic invalidation when metrics change significantly (>10%)
- Include fallback static quotes when OpenAI is unavailable
- Update frontend StatsPanel to fetch quotes from the API with loading state

## Technical Details
- **Backend**: New endpoint with caching, OpenAI client initialization from `OPENAI_API_KEY` env var
- **Frontend**: `useState` + `useEffect` for async quote fetching, graceful fallback on errors
- **Caching**: In-memory `QuoteCache` dataclass with TTL and metrics hash comparison

## Test plan
- [ ] Run backend tests: `cd aggregator && pytest`
- [ ] Verify quote endpoint locally: `curl http://localhost:8000/api/quote/dwight-pi`
- [ ] Test frontend quote display when selecting a node
- [ ] Verify caching (subsequent requests return cached quote)
- [ ] Test fallback quotes work when OpenAI API key is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)