### PR TITLE
chore: upgrade Python from 3.11 to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.31.0
-kubernetes==28.1.0
-psutil==5.9.6
-speedtest-cli==2.1.3
+requests>=2.32.0
+kubernetes>=31.0.0
+psutil>=6.0.0
+speedtest-cli>=2.1.3

--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/aggregator/requirements.txt
+++ b/aggregator/requirements.txt
@@ -1,8 +1,8 @@
-fastapi==0.104.1
-uvicorn==0.24.0
-pydantic==2.5.0
-python-dateutil==2.8.2
-pytest==7.4.3
-pytest-asyncio==0.21.1
-httpx==0.25.2
+fastapi>=0.115.0
+uvicorn>=0.32.0
+pydantic>=2.10.0
+python-dateutil>=2.9.0
+pytest>=8.3.0
+pytest-asyncio>=0.24.0
+httpx>=0.27.0
 openai>=1.0.0


### PR DESCRIPTION
## Summary
- Upgrade Python version from 3.11 to 3.13 across all components
- Bump dependencies to versions with Python 3.13 pre-built wheels

## Python 3.13 Changes
- `aggregator/Dockerfile`
- `agent/Dockerfile`
- `.github/workflows/ci.yml`

## Dependency Updates (for cp313 wheel support)

**Aggregator:**
| Package | Old | New |
|---------|-----|-----|
| pydantic | 2.5.0 | >=2.10.0 |
| fastapi | 0.104.1 | >=0.115.0 |
| uvicorn | 0.24.0 | >=0.32.0 |
| pytest | 7.4.3 | >=8.3.0 |
| pytest-asyncio | 0.21.1 | >=0.24.0 |
| httpx | 0.25.2 | >=0.27.0 |

**Agent:**
| Package | Old | New |
|---------|-----|-----|
| requests | 2.31.0 | >=2.32.0 |
| kubernetes | 28.1.0 | >=31.0.0 |
| psutil | 5.9.6 | >=6.0.0 |

## Why bump dependencies?
pydantic 2.5.0 predates Python 3.13 and has no cp313 wheels. Without pre-built wheels, pip would try to compile pydantic-core from source (requires Rust). Bumping to pydantic>=2.10.0 ensures wheels are available.

## Test plan
- [ ] CI pipeline passes with Python 3.13
- [ ] Backend tests pass
- [ ] Docker builds succeed (no Rust compilation needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)