### PR TITLE
fix: avoid release tag collisions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
         id: current_tag
         run: |
           set -euo pipefail
-          latest="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+          latest="$(git tag --list 'v*' --sort=-v:refname | head -n 1 || true)"
           if [[ -z "$latest" ]]; then
             base="0.0.0"
           else


### PR DESCRIPTION
## Summary
- use highest semver tag to calculate next version
- prevent collisions when newer tags exist off the current history

## Testing
- not run (workflow change)