### PR TITLE
fix: use correct AGGREGATOR_URL in StatsPanel for production

### DIFF
--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -5,7 +5,9 @@ import { formatBytesPerSecond } from '../utils/format';
 import { getCharacterFromNodeName, getCharacterImage, getCharacterQuote } from '../utils/characterUtils';
 import './StatsPanel.css';
 
-const AGGREGATOR_URL = process.env.REACT_APP_AGGREGATOR_URL || 'http://localhost:8000';
+// Use relative path in production (behind ingress), or env var for local dev
+const AGGREGATOR_URL = process.env.REACT_APP_AGGREGATOR_URL ||
+  (typeof window !== 'undefined' && window.location.hostname === 'localhost' ? 'http://localhost:8000' : '');
 
 // Format a timestamp as relative time (e.g., "2s ago", "5m ago")
 const formatRelativeTime = (timestamp: number | string | undefined): string => {


### PR DESCRIPTION
## Problem
AI quotes aren't showing in production. The `/api/quote` endpoint works (tested via curl), but the frontend isn't fetching quotes.

**Root cause:** `StatsPanel.tsx` had:
```js
const AGGREGATOR_URL = process.env.REACT_APP_AGGREGATOR_URL || 'http://localhost:8000';
```

In production, this tries to fetch from `http://localhost:8000` which fails.

## Solution
Match the pattern used in `App.tsx`:
```js
const AGGREGATOR_URL = process.env.REACT_APP_AGGREGATOR_URL ||
  (window.location.hostname === 'localhost' ? 'http://localhost:8000' : '');
```

In production, uses empty string (relative URL) which works behind the ingress.

## Test plan
- [ ] Deploy frontend update  
- [ ] Click on a node - should see AI-generated quote

🤖 Generated with [Claude Code](https://claude.com/claude-code)