### PR TITLE
feat: upgrade quote generation to GPT-5.2 with improved prompt

### DIFF
--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -695,17 +695,31 @@ async def _generate_quote(character: str, node_name: str, node_data: dict) -> st
 
     full_name = character_names.get(character, character.title())
 
-    prompt = f"""Generate a short, funny quote in the style of {full_name} from The Office (US). Reference these server metrics humorously:
-{metrics_str}
+    prompt = f"""You are a deadpan SRE comedian writing short quips for a homelab status dashboard.
+Each machine is themed after a character from "The Office" (US).
 
-1-2 sentences max. Output only the quote."""
+Goal:
+Write a single-line quote as if that character is speaking ABOUT THEIR CURRENT METRICS.
+
+Rules:
+- Capture the character's vibe using original wording.
+- Reference 1–2 metrics explicitly (numbers or comparisons).
+- Make it a relevant joke based on the metrics (CPU, memory, temp, disk, uptime, pods, etc.).
+- Length: 8–20 words.
+- No emojis.
+
+Character: {full_name}
+Node: {node_name}
+Metrics: {metrics_str}
+
+Quote:"""
 
     try:
         response = await openai_client.chat.completions.create(
-            model="gpt-4.1-mini",
+            model="gpt-5.2",
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=100,
-            temperature=0.8,
+            max_completion_tokens=100,
+            temperature=0.9,
         )
         quote = response.choices[0].message.content.strip()
         # Remove surrounding quotes if present


### PR DESCRIPTION
## Summary
- Upgrade from `gpt-4.1-mini` to `gpt-5.2` for better character voice capture
- New "deadpan SRE comedian" prompt produces shorter, punchier quotes (8-20 words)
- Use `max_completion_tokens` (GPT-5.2 API requirement)

## Before (gpt-4.1-mini)
> "At 95% CPU and 88% memory, I am working harder than Michael on Pretzel Day; my temperature of 61°C is just my beet-fueled core showing true dedication."

## After (gpt-5.2)
> CPU at 95%, memory 88%—I'm not overheating; I'm sharpening at 61°C.

## Sample outputs

| Node | Quote |
|------|-------|
| michael-pi | I'm running at 78% CPU, 52°C—basically a warm, productive regional manager. |
| jim-pi | CPU's at 12%, memory 22%—I've been quietly running 45 days. Prank accomplished. |
| dwight-pi | CPU at 95%, memory 88%—I'm not overheating; I'm sharpening at 61°C. |

## Cost impact
~$0.25/month vs ~$0.01/month (negligible at 180 queries/month)

## Test plan
- [ ] Deploy to staging and verify quotes generate
- [ ] Check logs for any API errors
- [ ] Verify quote caching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)