### PR TITLE
[codex] Improve frontend operations cockpit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,19 @@
 This document captures the conventions that show up repeatedly across the repo so future
 changes feel cohesive.
 
+## Quick Commands (CI Parity)
+- Aggregator tests (matches CI’s `PYTHONPATH` setup):
+  - From repo root:
+    - `python -m pip install -r aggregator/requirements.txt`
+    - `PYTHONPATH="$PWD" python -m pytest aggregator/tests -v`
+- Frontend checks:
+  - `cd frontend`
+  - `npm install`
+  - `npm run lint`
+  - `npm run type-check`
+  - `npm run build`
+  - `npm test -- --watchAll=false`
+
 ## Repository-wide
 - This project is split into three services (`agent/`, `aggregator/`, `frontend/`) plus helper
   scripts. Keep service-specific configuration in its folder and update the related
@@ -11,9 +24,11 @@ changes feel cohesive.
 - Use descriptive logging—each service already initialises a module-level logger. Prefer
   structured log messages over `print` statements.
 - When a change affects an API contract or data shape, update every consumer: the agent’s
-  payload builder, the aggregator’s Pydantic models, and the frontend TypeScript interfaces.
-- Shell helpers in `scripts/` assume GNU utilities. Keep them POSIX-friendly and guard
-  external commands with clear error messages like the existing build script.
+  payload builder (`agent/agent.py`), the aggregator’s Pydantic models (`aggregator/main.py`),
+  and the frontend TypeScript interfaces (`frontend/src/types.ts`).
+- Shell helpers in `scripts/` are `bash` scripts intended to be run from the repository root.
+  Guard external commands (`docker`, `kubectl`, etc.) with clear error messages like the
+  existing scripts.
 - Docker image builds are orchestrated through the provided `Makefile` and `scripts/*.sh`
   helpers. Prefer extending those instead of introducing parallel workflows.
 
@@ -37,17 +52,20 @@ changes feel cohesive.
 ## Frontend (`frontend/`)
 - The React app is written in TypeScript with functional components and hooks. New data types
   belong in `src/types.ts`, and components should receive typed props instead of using `any`.
-- Map-related UI lives in `src/components/` alongside a `.css` file per component. Continue the
+- Map UI lives in `src/components/` alongside a `.css` file per component. Continue the
   co-located styling approach, and scope new styles with descriptive class names rather than
   global element selectors.
 - Network calls use `axios` with URLs derived from `REACT_APP_AGGREGATOR_URL`. Reuse the shared
-  polling helper in `App.tsx` or pass data down via props—avoid duplicating fetch logic inside
+  polling in `src/App.tsx` or pass data down via props—avoid adding new polling loops in
   deeply nested components.
 - Respect the dark/light theme toggle by toggling the `dark-mode` / `light-mode` root classes.
   When adding UI, provide compatible styles for both themes.
-- Leaflet markers rely on custom HTML markers and clustered layers. When adding map features,
-  ensure they play nicely with `MarkerClusterGroup` and avoid forcing the map to re-fit bounds
-  on every refresh (see the `FitBounds` hook for the established pattern).
+- Map implementations:
+  - Globe view: `frontend/src/components/ClusterMap.tsx` (`react-globe.gl`)
+  - Flat view: `frontend/src/components/FlatMap.tsx` (`d3-geo` + SVG)
+  - Deck overlay: `frontend/src/components/DeckGLMap.tsx` (`deck.gl`)
+  Keep interactions stable across refreshes (don’t re-center/re-zoom on every poll tick) and
+  prefer memoized callbacks/state updates so telemetry refreshes don’t re-trigger camera moves.
 
 ## Scripts (`scripts/`)
 - Scripts are meant to be run from the repository root and start with `set -e`. Use emoji-rich

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ A real-time visualization tool for monitoring your k3s homelab cluster across mu
    ```
    The agent falls back to Berlin, Germany when these variables are omitted. Find coordinates at https://www.latlong.net/.
 
-2. **Update Docker registry** - Edit image names in `k8s/*.yaml` or set env var:
+2. **Update Docker registry** - Update image names in your Kubernetes manifests (wherever you keep them) or set env var:
    ```bash
    export REGISTRY=docker.io/yourusername
    ```
+   Note: This repo focuses on building images and running locally; Kubernetes manifests may
+   live in a separate deployments repo. If you use `make deploy`, set
+   `HOMELAB_MAP_MANIFESTS_DIR` to the folder containing your manifests.
 
 ### Configuration
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,13 +13,8 @@ This guide will walk you through deploying the homelab-map application to your k
 
 ### 1. Configure Your Docker Registry
 
-Edit the following files and replace `your-registry/` with your actual registry:
-
-```bash
-# k8s/agent-daemonset.yaml
-# k8s/aggregator-deployment.yaml
-# k8s/frontend-deployment.yaml
-```
+Edit your Kubernetes manifests (wherever you keep them) and replace `your-registry/` with
+your actual registry.
 
 Or set the `REGISTRY` environment variable:
 
@@ -73,6 +68,7 @@ export VERSION=v1.0.0
 make deploy
 
 # Or manually:
+export HOMELAB_MAP_MANIFESTS_DIR=/path/to/your/manifests
 ./scripts/deploy.sh
 ```
 
@@ -91,14 +87,11 @@ Then open: http://localhost:3000
 
 #### Option B: Ingress (Production)
 
-1. Update `k8s/ingress.yaml` with your domain:
-```yaml
-- host: homelab-map.yourdomain.com
-```
+1. Update your ingress manifest with your domain (in your own manifests directory).
 
-2. Apply the ingress:
+2. Apply the ingress from your manifests directory (or any file path you maintain):
 ```bash
-kubectl apply -f k8s/ingress.yaml
+kubectl apply -f "$HOMELAB_MAP_MANIFESTS_DIR"
 ```
 
 3. Access via your domain: https://homelab-map.yourdomain.com

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,80 +1,137 @@
 .App {
-  height: 100vh;
+  min-height: 100vh;
   width: 100vw;
   display: flex;
   flex-direction: column;
 }
 
-/* Dark mode header */
-.dark-mode .app-header {
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-  color: white;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+.dark-mode {
+  --app-bg: #08111f;
+  --header-surface: linear-gradient(135deg, rgba(8, 17, 31, 0.96), rgba(12, 32, 49, 0.92));
+  --header-border: rgba(136, 198, 255, 0.16);
+  --header-copy: #e8f2ff;
+  --header-muted: rgba(209, 227, 247, 0.75);
+  --metric-surface: rgba(10, 24, 40, 0.68);
+  --metric-border: rgba(136, 198, 255, 0.18);
+  --toggle-surface: rgba(255, 255, 255, 0.08);
+  --toggle-surface-hover: rgba(255, 255, 255, 0.14);
+  --banner-error: #b93b3b;
+  --banner-info: #24597f;
 }
 
-/* Light mode header */
-.light-mode .app-header {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+.light-mode {
+  --app-bg: #eef4f7;
+  --header-surface: linear-gradient(135deg, rgba(247, 250, 252, 0.96), rgba(222, 236, 240, 0.94));
+  --header-border: rgba(26, 69, 98, 0.12);
+  --header-copy: #142433;
+  --header-muted: rgba(20, 36, 51, 0.68);
+  --metric-surface: rgba(255, 255, 255, 0.82);
+  --metric-border: rgba(26, 69, 98, 0.1);
+  --toggle-surface: rgba(20, 36, 51, 0.08);
+  --toggle-surface-hover: rgba(20, 36, 51, 0.14);
+  --banner-error: #cd5544;
+  --banner-info: #2a6a8d;
 }
 
 .app-header {
-  padding: 1rem 2rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  position: relative;
   z-index: 1000;
+  padding: 1.25rem 1.5rem 1rem;
+  background: var(--header-surface);
+  color: var(--header-copy);
+  border-bottom: 1px solid var(--header-border);
+  box-shadow: 0 16px 40px rgba(2, 8, 17, 0.18);
+  backdrop-filter: blur(22px);
 }
 
-@media (max-width: 768px) {
-  .app-header {
-    padding: 0.75rem 1rem;
-  }
+.app-header::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(122, 213, 255, 0.55), transparent);
+  opacity: 0.7;
 }
 
 .header-content {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.header-top-row {
+  display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
 }
 
 .header-left {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 1rem;
+  min-width: 0;
 }
 
-.sidebar-toggle {
-  display: none;
-  background: rgba(255, 255, 255, 0.2);
-  border: none;
-  border-radius: 8px;
-  padding: 0.5rem 1rem;
-  font-size: 1.2rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  color: white;
+.brand-block {
+  min-width: 0;
 }
 
-.sidebar-toggle:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: scale(1.1);
+.brand-kicker {
+  display: inline-block;
+  margin-bottom: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #7ad5ff;
 }
 
-@media (max-width: 768px) {
-  .sidebar-toggle {
-    display: block;
-  }
-  
-  .header-left h1 {
-    font-size: 1.2rem;
-  }
+.brand-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .app-header h1 {
   margin: 0;
-  font-size: 1.5rem;
-  font-weight: 600;
+  font-size: clamp(1.55rem, 3vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.brand-subtitle {
+  margin: 0.45rem 0 0;
+  max-width: 72ch;
+  color: var(--header-muted);
+  font-size: 0.96rem;
+  line-height: 1.5;
+}
+
+.telemetry-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.38rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.telemetry-pill.live {
+  background: rgba(52, 199, 115, 0.18);
+  color: #87efb0;
+  border-color: rgba(52, 199, 115, 0.28);
+}
+
+.telemetry-pill.mock {
+  background: rgba(255, 174, 66, 0.18);
+  color: #ffd8a3;
+  border-color: rgba(255, 174, 66, 0.28);
 }
 
 .header-right {
@@ -83,42 +140,94 @@
   gap: 0.75rem;
 }
 
+.sidebar-toggle,
 .interactive-toggle,
 .theme-toggle {
-  background: rgba(255, 255, 255, 0.2);
   border: none;
-  border-radius: 8px;
-  padding: 0.5rem 1rem;
-  font-size: 1.2rem;
+  border-radius: 14px;
+  padding: 0.7rem 0.9rem;
+  background: var(--toggle-surface);
+  color: inherit;
   cursor: pointer;
-  transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  backdrop-filter: blur(12px);
 }
 
+.theme-toggle {
+  min-width: 48px;
+}
+
+.sidebar-toggle:hover,
 .interactive-toggle:hover,
 .theme-toggle:hover {
-  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-1px);
+  background: var(--toggle-surface-hover);
 }
 
 .interactive-toggle.active {
-  background: rgba(255, 215, 0, 0.4);
-  box-shadow: 0 0 8px rgba(255, 215, 0, 0.5);
-  transform: scale(1.1);
+  background: rgba(255, 215, 0, 0.24);
+  box-shadow: 0 0 0 1px rgba(255, 215, 0, 0.12) inset;
+}
+
+.light-mode .interactive-toggle.active {
+  background: rgba(218, 165, 32, 0.18);
+}
+
+.sidebar-toggle {
+  display: none;
+}
+
+.header-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.header-metric-card {
+  padding: 0.95rem 1rem;
+  border-radius: 18px;
+  background: var(--metric-surface);
+  border: 1px solid var(--metric-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.header-metric-label {
+  color: var(--header-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.header-metric-card strong {
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.header-metric-detail {
+  color: var(--header-muted);
+  font-size: 0.86rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .error-banner {
-  background-color: #f44336;
+  margin-top: 0.85rem;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  background: var(--banner-error);
   color: white;
-  padding: 0.5rem 1rem;
-  margin-top: 0.5rem;
-  border-radius: 4px;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .error-banner.info-banner {
-  background-color: #2196F3;
+  background: var(--banner-info);
 }
 
 .app-content {
@@ -126,16 +235,17 @@
   display: flex;
   position: relative;
   overflow: hidden;
+  background:
+    radial-gradient(circle at top left, rgba(55, 164, 255, 0.16), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(255, 165, 91, 0.14), transparent 28%),
+    var(--app-bg);
 }
 
 .sidebar-overlay {
   display: none;
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background: rgba(3, 9, 18, 0.48);
   z-index: 1500;
   opacity: 0;
   pointer-events: none;
@@ -147,27 +257,13 @@
   pointer-events: all;
 }
 
-@media (max-width: 768px) {
-  .sidebar-overlay {
-    display: block;
-  }
-}
-
 .map-loading {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--header-muted);
   font-size: 1rem;
-}
-
-.dark-mode .map-loading {
-  color: rgba(255, 255, 255, 0.75);
-}
-
-.light-mode .map-loading {
-  color: #333;
 }
 
 .loading-container {
@@ -176,23 +272,82 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  gap: 0.75rem;
+  background:
+    radial-gradient(circle at top, rgba(84, 188, 255, 0.22), transparent 30%),
+    linear-gradient(160deg, #091321 0%, #13314a 52%, #091321 100%);
   color: white;
 }
 
 .loading-spinner {
-  border: 4px solid rgba(255, 255, 255, 0.3);
+  border: 4px solid rgba(255, 255, 255, 0.14);
   border-radius: 50%;
-  border-top: 4px solid white;
+  border-top: 4px solid #7ad5ff;
   width: 50px;
   height: 50px;
   animation: spin 1s linear infinite;
-  margin-bottom: 1rem;
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 1024px) {
+  .header-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    padding: 1rem;
+  }
+
+  .header-top-row {
+    align-items: center;
+  }
+
+  .sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .brand-subtitle {
+    font-size: 0.9rem;
+  }
+
+  .header-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar-overlay {
+    display: block;
+  }
+}
+
+@media (max-width: 520px) {
+  .header-left {
+    gap: 0.75rem;
+  }
+
+  .brand-kicker {
+    font-size: 0.66rem;
+  }
+
+  .app-header h1 {
+    font-size: 1.45rem;
+  }
+
+  .telemetry-pill {
+    font-size: 0.7rem;
+  }
 }
 
 /* Password Modal Styles */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import axios from 'axios';
 import StatsPanel from './components/StatsPanel';
 import { Node, ClusterStats, Connection } from './types';
 import { mockNodes, mockConnections, mockStats } from './mockData';
+import { getAttentionNodes, getNodeTrafficTotal } from './utils/clusterInsights';
+import { formatBytesPerSecond } from './utils/format';
 import './App.css';
 
 // Password modal state
@@ -21,6 +23,28 @@ const REFRESH_INTERVAL = 15000; // 15 seconds (reduced from 10s to lower server 
 const REFRESH_INTERVAL_BACKGROUND = 60000; // 60 seconds when tab is hidden
 const USE_MOCK_DATA = process.env.REACT_APP_USE_MOCK_DATA === 'true' || false;
 
+const formatRefreshAge = (timestamp: number | null): string => {
+  if (!timestamp) {
+    return 'waiting for telemetry';
+  }
+
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (diffSeconds < 5) {
+    return 'just now';
+  }
+  if (diffSeconds < 60) {
+    return `${diffSeconds}s ago`;
+  }
+
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) {
+    return `${diffMinutes}m ago`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  return `${diffHours}h ago`;
+};
+
 function App() {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [stats, setStats] = useState<ClusterStats | null>(null);
@@ -30,6 +54,8 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [selection, setSelection] = useState<{ id: string; token: number } | null>(null);
   const [zoomOnly, setZoomOnly] = useState(false);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [usingMockData, setUsingMockData] = useState(USE_MOCK_DATA);
   
   // Load theme preference from localStorage, default to light mode
   const [darkMode, setDarkMode] = useState(() => {
@@ -108,7 +134,10 @@ function App() {
       setNodes(mockNodes);
       setStats(mockStats);
       setConnections(mockConnections);
+      setConnectionsTotal(mockConnections.length);
       setError(null);
+      setUsingMockData(true);
+      setLastUpdatedAt(Date.now());
       setLoading(false);
       return;
     }
@@ -203,6 +232,8 @@ function App() {
       });
 
       setError(null);
+      setUsingMockData(false);
+      setLastUpdatedAt(Date.now());
     } catch (err) {
       console.error('Error fetching data:', err);
       console.log('Falling back to mock data...');
@@ -210,7 +241,10 @@ function App() {
       setNodes(mockNodes);
       setStats(mockStats);
       setConnections(mockConnections);
+      setConnectionsTotal(mockConnections.length);
       setError('Using mock data - aggregator unavailable');
+      setUsingMockData(true);
+      setLastUpdatedAt(Date.now());
     } finally {
       setLoading(false);
     }
@@ -291,6 +325,43 @@ function App() {
     setZoomOnly(false);
   }, []);
 
+  const providerCount = useMemo(
+    () => Object.keys(stats?.providers ?? {}).length,
+    [stats]
+  );
+
+  const attentionNodes = useMemo(() => getAttentionNodes(nodes), [nodes]);
+  const attentionCount = attentionNodes.length;
+
+  const totalTraffic = useMemo(
+    () => nodes.reduce((sum, node) => sum + getNodeTrafficTotal(node), 0),
+    [nodes]
+  );
+
+  const busiestNode = useMemo(() => {
+    return nodes.reduce<Node | null>((busiest, node) => {
+      if (!busiest) {
+        return node;
+      }
+      return getNodeTrafficTotal(node) > getNodeTrafficTotal(busiest) ? node : busiest;
+    }, null);
+  }, [nodes]);
+
+  const onlineRate = useMemo(() => {
+    if (!stats || stats.total_nodes === 0) {
+      return 0;
+    }
+    return Math.round((stats.online_nodes / stats.total_nodes) * 100);
+  }, [stats]);
+
+  const averageLatency = useMemo(() => {
+    if (connections.length === 0) {
+      return 0;
+    }
+    const total = connections.reduce((sum, connection) => sum + connection.latency_ms, 0);
+    return total / connections.length;
+  }, [connections]);
+
   if (loading) {
     return (
       <div className="loading-container">
@@ -304,33 +375,83 @@ function App() {
     <div className={`App ${darkMode ? 'dark-mode' : 'light-mode'}`}>
       <header className="app-header">
         <div className="header-content">
-          <div className="header-left">
-            <button 
-              className="sidebar-toggle"
-              onClick={() => setSidebarOpen(!sidebarOpen)}
-              aria-label="Toggle sidebar"
-              aria-expanded={sidebarOpen}
-            >
-              ☰
-            </button>
-            <h1>Dunder Mifflin</h1>
+          <div className="header-top-row">
+            <div className="header-left">
+              <button
+                className="sidebar-toggle"
+                onClick={() => setSidebarOpen(!sidebarOpen)}
+                aria-label="Toggle sidebar"
+                aria-expanded={sidebarOpen}
+              >
+                ☰
+              </button>
+              <div className="brand-block">
+                <div className="brand-kicker">Homelab operations</div>
+                <div className="brand-title-row">
+                  <h1>Dunder Mifflin Atlas</h1>
+                  <span className={`telemetry-pill ${usingMockData ? 'mock' : 'live'}`}>
+                    {usingMockData ? 'Mock telemetry' : 'Live telemetry'}
+                  </span>
+                </div>
+                <p className="brand-subtitle">
+                  {stats?.total_nodes ?? nodes.length} nodes across {providerCount} providers.
+                  {' '}
+                  {attentionCount > 0
+                    ? `${attentionCount} ${attentionCount === 1 ? 'node needs' : 'nodes need'} attention.`
+                    : 'Cluster stable.'}
+                  {' '}
+                  Refreshed {formatRefreshAge(lastUpdatedAt)}.
+                </p>
+              </div>
+            </div>
+            <div className="header-right">
+              <button
+                className={`interactive-toggle ${interactiveMode ? 'active' : ''}`}
+                onClick={() => interactiveMode ? setInteractiveMode(false) : setShowPasswordModal(true)}
+                aria-label="Toggle interactive mode"
+                title={interactiveMode ? 'Disable interactive AI quotes' : 'Enable interactive AI quotes'}
+              >
+                {interactiveMode ? '🎭' : '🔒'}
+              </button>
+              <button
+                className="theme-toggle"
+                onClick={() => setDarkMode(!darkMode)}
+                aria-label="Toggle theme"
+              >
+                {darkMode ? '☀️' : '🌙'}
+              </button>
+            </div>
           </div>
-          <div className="header-right">
-            <button
-              className={`interactive-toggle ${interactiveMode ? 'active' : ''}`}
-              onClick={() => interactiveMode ? setInteractiveMode(false) : setShowPasswordModal(true)}
-              aria-label="Toggle interactive mode"
-              title={interactiveMode ? 'Disable interactive AI quotes' : 'Enable interactive AI quotes'}
-            >
-              {interactiveMode ? '🎭' : '🔒'}
-            </button>
-            <button
-              className="theme-toggle"
-              onClick={() => setDarkMode(!darkMode)}
-              aria-label="Toggle theme"
-            >
-              {darkMode ? '☀️' : '🌙'}
-            </button>
+
+          <div className="header-metrics">
+            <div className="header-metric-card">
+              <span className="header-metric-label">Availability</span>
+              <strong>{onlineRate}%</strong>
+              <span className="header-metric-detail">
+                {stats?.online_nodes ?? 0}/{stats?.total_nodes ?? nodes.length} nodes online
+              </span>
+            </div>
+            <div className="header-metric-card">
+              <span className="header-metric-label">Attention</span>
+              <strong>{attentionCount}</strong>
+              <span className="header-metric-detail">
+                {attentionCount > 0 ? attentionNodes[0].node.name : 'No active alerts'}
+              </span>
+            </div>
+            <div className="header-metric-card">
+              <span className="header-metric-label">Network load</span>
+              <strong>{formatBytesPerSecond(totalTraffic)}</strong>
+              <span className="header-metric-detail">
+                {busiestNode ? `Top talker: ${busiestNode.name}` : 'No traffic yet'}
+              </span>
+            </div>
+            <div className="header-metric-card">
+              <span className="header-metric-label">Latency</span>
+              <strong>{averageLatency.toFixed(1)} ms</strong>
+              <span className="header-metric-detail">
+                {connections.length} rendered links
+              </span>
+            </div>
           </div>
         </div>
         {error && (

--- a/frontend/src/components/StatsPanel.css
+++ b/frontend/src/components/StatsPanel.css
@@ -134,13 +134,19 @@
 }
 
 .stats-panel.dark {
-  background: #1e1e1e;
-  color: #e0e0e0;
+  background:
+    radial-gradient(circle at top left, rgba(45, 139, 197, 0.14), transparent 28%),
+    linear-gradient(180deg, rgba(9, 20, 34, 0.97), rgba(8, 16, 28, 0.98));
+  color: #e6eff7;
+  border-right: 1px solid rgba(118, 175, 224, 0.14);
 }
 
 .stats-panel.light {
-  background: #ffffff;
-  color: #333;
+  background:
+    radial-gradient(circle at top left, rgba(132, 194, 219, 0.22), transparent 28%),
+    linear-gradient(180deg, rgba(251, 253, 255, 0.98), rgba(239, 244, 247, 0.96));
+  color: #243443;
+  border-right: 1px solid rgba(26, 69, 98, 0.08);
 }
 
 .stats-panel.showing-details .stats-section:not(.node-details) {
@@ -170,22 +176,152 @@
   padding-bottom: 0.5rem;
 }
 
+.section-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.section-badge {
+  padding: 0.28rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.stats-panel.dark .section-badge {
+  background: rgba(122, 213, 255, 0.12);
+  color: #9ee4ff;
+}
+
+.stats-panel.light .section-badge {
+  background: rgba(28, 110, 140, 0.1);
+  color: #1c6e8c;
+}
+
+.section-badge.active {
+  background: rgba(242, 105, 77, 0.14);
+  color: #ffb19b;
+}
+
+.stats-panel.light .section-badge.active {
+  color: #a94834;
+}
+
+.attention-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.attention-card {
+  border: none;
+  border-radius: 16px;
+  padding: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  font: inherit;
+  color: inherit;
+}
+
+.stats-panel.dark .attention-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.stats-panel.light .attention-card {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(20, 36, 51, 0.08);
+}
+
+.attention-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 22px rgba(5, 17, 29, 0.12);
+}
+
+.attention-card:focus-visible {
+  outline: 2px solid #2ba7cc;
+  outline-offset: 2px;
+}
+
+.attention-card.status-offline {
+  border-left: 4px solid #d55f4b;
+}
+
+.attention-card.status-warning {
+  border-left: 4px solid #f59d39;
+}
+
+.attention-card.status-online {
+  border-left: 4px solid #24a16b;
+}
+
+.attention-card__header,
+.attention-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.attention-card__name {
+  font-weight: 700;
+}
+
+.attention-card__severity {
+  font-size: 0.78rem;
+  font-weight: 700;
+  opacity: 0.68;
+}
+
+.attention-card__reason {
+  margin: 0.35rem 0 0.5rem;
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.attention-card__meta {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.attention-empty {
+  padding: 0.85rem 0.95rem;
+  border-radius: 14px;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.stats-panel.dark .attention-empty {
+  background: rgba(255, 255, 255, 0.04);
+  color: #b8c8d7;
+}
+
+.stats-panel.light .attention-empty {
+  background: rgba(255, 255, 255, 0.75);
+  color: #4d6376;
+}
+
 .stat-card {
   display: flex;
   align-items: center;
   gap: 1rem;
   padding: 1rem;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border-radius: 8px;
+  background: linear-gradient(135deg, #1e5f86 0%, #0d8db8 100%);
+  border-radius: 16px;
   color: white;
+  box-shadow: 0 18px 30px rgba(7, 22, 39, 0.18);
 }
 
 .stat-card.online {
-  background: linear-gradient(135deg, #4caf50 0%, #388e3c 100%);
+  background: linear-gradient(135deg, #177e5e 0%, #24a16b 100%);
 }
 
 .stat-card.offline {
-  background: linear-gradient(135deg, #f44336 0%, #d32f2f 100%);
+  background: linear-gradient(135deg, #af453a 0%, #d55f4b 100%);
 }
 
 .stat-icon {
@@ -262,15 +398,15 @@
 }
 
 .progress-fill.cpu {
-  background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(90deg, #1c6e8c 0%, #25a0bf 100%);
 }
 
 .progress-fill.memory {
-  background: linear-gradient(90deg, #f093fb 0%, #f5576c 100%);
+  background: linear-gradient(90deg, #f59d39 0%, #f2694d 100%);
 }
 
 .progress-fill.disk {
-  background: linear-gradient(90deg, #4facfe 0%, #00f2fe 100%);
+  background: linear-gradient(90deg, #3c88f7 0%, #4cc8ff 100%);
 }
 
 .throughput-cards {
@@ -338,7 +474,7 @@
 }
 
 .provider-count {
-  background: #667eea;
+  background: #1c6e8c;
   color: white;
   padding: 2px 10px;
   border-radius: 12px;
@@ -350,22 +486,68 @@
   /* No max-height, let the parent panel handle scrolling */
 }
 
+.node-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.node-search__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.node-search input {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 0.7rem 0.8rem;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.stats-panel.dark .node-search input {
+  background: rgba(255, 255, 255, 0.06);
+  color: #f0f6fc;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.stats-panel.light .node-search input {
+  background: rgba(255, 255, 255, 0.88);
+  color: #243443;
+  border-color: rgba(20, 36, 51, 0.08);
+}
+
+.node-search input::placeholder {
+  color: rgba(121, 138, 154, 0.9);
+}
+
+.node-search input:focus {
+  outline: none;
+  border-color: #2ba7cc;
+  box-shadow: 0 0 0 3px rgba(43, 167, 204, 0.16);
+}
+
 .stats-panel.dark .node-item {
   background: rgba(255, 255, 255, 0.05);
-  border-left: 4px solid #555;
+  border-left: 4px solid rgba(255, 255, 255, 0.18);
 }
 
 .stats-panel.light .node-item {
-  background: #f8f9fa;
-  border-left: 4px solid #ccc;
+  background: rgba(255, 255, 255, 0.84);
+  border-left: 4px solid rgba(20, 36, 51, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .node-item {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.6rem 0.8rem;
-  border-radius: 6px;
+  gap: 0.45rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 14px;
   font-size: 0.85rem;
   border: none;
   width: 100%;
@@ -378,21 +560,21 @@
 }
 
 .node-item:focus-visible {
-  outline: 2px solid #667eea;
+  outline: 2px solid #2ba7cc;
   outline-offset: 2px;
 }
 
 .node-item.active {
   transform: translateX(4px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 16px 28px rgba(5, 17, 29, 0.18);
 }
 
 .stats-panel.dark .node-item.active {
-  background: rgba(102, 126, 234, 0.2);
+  background: rgba(31, 118, 150, 0.24);
 }
 
 .stats-panel.light .node-item.active {
-  background: rgba(102, 126, 234, 0.15);
+  background: rgba(77, 168, 204, 0.14);
 }
 
 .node-item-header {
@@ -472,12 +654,47 @@
   color: #f44336;
 }
 
+.node-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.74rem;
+  color: inherit;
+  opacity: 0.7;
+}
+
+.node-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-alert-tag {
+  align-self: flex-start;
+  padding: 0.26rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.stats-panel.dark .node-alert-tag {
+  background: rgba(255, 174, 66, 0.16);
+  color: #ffd8a3;
+}
+
+.stats-panel.light .node-alert-tag {
+  background: rgba(242, 105, 77, 0.12);
+  color: #a94834;
+}
+
 .node-throughput {
   display: flex;
   justify-content: space-between;
   font-size: 0.75rem;
   gap: 0.5rem;
   color: inherit;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Node Details Section */

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,8 +1,9 @@
-import React, { memo, useState, useEffect } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import { ClusterStats, Node } from '../types';
 import { formatBytesPerSecond } from '../utils/format';
 import { getCharacterFromNodeName, getCharacterImage, getCharacterQuote, capitalizeCharacterName } from '../utils/characterUtils';
+import { getAttentionNodes, getNodeInsight } from '../utils/clusterInsights';
 import './StatsPanel.css';
 
 // Use relative path in production (behind ingress), or env var for local dev
@@ -147,8 +148,35 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
   const [quote, setQuote] = useState<string | null>(null);
   const [quoteLoading, setQuoteLoading] = useState(false);
   const [clicksRemaining, setClicksRemaining] = useState(DAILY_QUOTE_LIMIT - getClickCount());
+  const [nodeSearch, setNodeSearch] = useState('');
 
   const selectedNode = selectedNodeId && showDetails ? nodes.find((node) => node.name === selectedNodeId) : null;
+  const attentionNodes = useMemo(() => getAttentionNodes(nodes, 4), [nodes]);
+  const filteredNodes = useMemo(() => {
+    const query = nodeSearch.trim().toLowerCase();
+
+    return nodes
+      .map((node) => ({ node, insight: getNodeInsight(node) }))
+      .filter(({ node, insight }) => {
+        if (!query) {
+          return true;
+        }
+
+        return [
+          node.name,
+          node.location ?? '',
+          node.provider ?? '',
+          insight.primaryReason ?? '',
+        ].some((value) => value.toLowerCase().includes(query));
+      })
+      .sort((left, right) => {
+        if (right.insight.severity !== left.insight.severity) {
+          return right.insight.severity - left.insight.severity;
+        }
+
+        return left.node.name.localeCompare(right.node.name);
+      });
+  }, [nodeSearch, nodes]);
 
   // Set static quote when node is selected (no automatic API call)
   useEffect(() => {
@@ -508,27 +536,70 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
             </div>
           </div>
 
+          <div className="stats-section">
+            <div className="section-heading-row">
+              <h2>Attention Queue</h2>
+              <span className={`section-badge ${attentionNodes.length === 0 ? 'quiet' : 'active'}`}>
+                {attentionNodes.length === 0 ? 'Quiet' : `${attentionNodes.length} active`}
+              </span>
+            </div>
+            {attentionNodes.length > 0 ? (
+              <div className="attention-list">
+                {attentionNodes.map((insight) => (
+                  <button
+                    key={insight.node.name}
+                    className={`attention-card status-${insight.node.status}`}
+                    onClick={() => {
+                      onNodeSelect(insight.node.name);
+                      if (onClose && window.innerWidth <= 768) {
+                        onClose();
+                      }
+                    }}
+                  >
+                    <div className="attention-card__header">
+                      <span className="attention-card__name">{insight.node.name}</span>
+                      <span className="attention-card__severity">{insight.severity}</span>
+                    </div>
+                    <div className="attention-card__reason">{insight.primaryReason}</div>
+                    <div className="attention-card__meta">
+                      <span>{insight.node.provider ?? 'Unknown provider'}</span>
+                      <span>{insight.node.location ?? 'Unknown location'}</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="attention-empty">
+                All nodes are reporting healthy telemetry right now.
+              </div>
+            )}
+          </div>
+
           <div className="stats-section nodes-list">
-            <h2>Nodes</h2>
-            {nodes.map((node) => (
-              <div
+            <div className="section-heading-row">
+              <h2>Nodes</h2>
+              <span className="section-badge">{filteredNodes.length}</span>
+            </div>
+            <label className="node-search">
+              <span className="node-search__label">Search nodes</span>
+              <input
+                type="text"
+                value={nodeSearch}
+                onChange={(event) => setNodeSearch(event.target.value)}
+                placeholder="Name, provider, location, alert"
+              />
+            </label>
+            {filteredNodes.map(({ node, insight }) => (
+              <button
                 key={node.name}
                 className={`node-item status-${node.status} ${
                   selectedNodeId === node.name ? 'active' : ''
                 }`}
-                role="button"
-                tabIndex={0}
                 onClick={() => {
                   onNodeSelect(node.name);
                   // Close sidebar on mobile after selection
                   if (onClose && window.innerWidth <= 768) {
                     onClose();
-                  }
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
-                    onNodeSelect(node.name);
                   }
                 }}
                 aria-pressed={selectedNodeId === node.name}
@@ -539,6 +610,13 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
                     {formatRelativeTime(node.last_seen_timestamp ?? node.last_seen)}
                   </div>
                 </div>
+                <div className="node-meta">
+                  <span>{node.provider ?? 'Unknown provider'}</span>
+                  <span>{node.location ?? 'Unknown location'}</span>
+                </div>
+                {insight.primaryReason && (
+                  <div className="node-alert-tag">{insight.primaryReason}</div>
+                )}
                 {(node.network_tx_bytes_per_sec !== undefined ||
                   node.network_rx_bytes_per_sec !== undefined) && (
                   <div className="node-throughput">
@@ -546,8 +624,13 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
                     <span>⬇ {formatBytesPerSecond(node.network_rx_bytes_per_sec)}</span>
                   </div>
                 )}
-              </div>
+              </button>
             ))}
+            {filteredNodes.length === 0 && (
+              <div className="attention-empty">
+                No nodes match the current filter.
+              </div>
+            )}
           </div>
         </>
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,11 +5,10 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Avenir Next', 'Segoe UI Variable', 'IBM Plex Sans', 'Trebuchet MS', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #08111f;
 }
 
 code {

--- a/frontend/src/utils/clusterInsights.test.ts
+++ b/frontend/src/utils/clusterInsights.test.ts
@@ -1,0 +1,86 @@
+import { Node } from '../types';
+import {
+  getAttentionNodes,
+  getNodeInsight,
+  getNodeLastSeenAgeSeconds,
+  getNodeTrafficTotal,
+} from './clusterInsights';
+
+const baseNode: Node = {
+  name: 'michael-1',
+  hostname: 'michael-1',
+  status: 'online',
+  last_seen: '5s ago',
+};
+
+describe('clusterInsights', () => {
+  it('sums total network traffic for a node', () => {
+    expect(
+      getNodeTrafficTotal({
+        ...baseNode,
+        network_tx_bytes_per_sec: 100,
+        network_rx_bytes_per_sec: 250,
+      })
+    ).toBe(350);
+  });
+
+  it('prefers explicit timestamps when calculating heartbeat age', () => {
+    expect(
+      getNodeLastSeenAgeSeconds(
+        {
+          ...baseNode,
+          last_seen_timestamp: 900,
+        },
+        1_000_000
+      )
+    ).toBe(100);
+  });
+
+  it('marks offline or overloaded nodes as needing attention', () => {
+    const insight = getNodeInsight(
+      {
+        ...baseNode,
+        status: 'offline',
+        cpu_percent: 92,
+        disk_percent: 94,
+        last_seen_timestamp: 700,
+      },
+      1_000_000
+    );
+
+    expect(insight.severity).toBeGreaterThan(150);
+    expect(insight.reasons).toContain('Offline');
+    expect(insight.reasons).toContain('CPU 92%');
+    expect(insight.reasons).toContain('Disk 94%');
+  });
+
+  it('sorts attention nodes by severity', () => {
+    const nodes: Node[] = [
+      {
+        ...baseNode,
+        name: 'jim-2',
+        hostname: 'jim-2',
+        status: 'warning',
+        last_seen_timestamp: 970,
+      },
+      {
+        ...baseNode,
+        name: 'dwight-3',
+        hostname: 'dwight-3',
+        status: 'offline',
+        last_seen_timestamp: 600,
+      },
+      {
+        ...baseNode,
+        name: 'pam-4',
+        hostname: 'pam-4',
+        status: 'online',
+        last_seen_timestamp: 995,
+      },
+    ];
+
+    const insights = getAttentionNodes(nodes, nodes.length, 1_000_000);
+
+    expect(insights.map((insight) => insight.node.name)).toEqual(['dwight-3', 'jim-2']);
+  });
+});

--- a/frontend/src/utils/clusterInsights.ts
+++ b/frontend/src/utils/clusterInsights.ts
@@ -1,0 +1,134 @@
+import { Node } from '../types';
+
+export interface NodeInsight {
+  node: Node;
+  severity: number;
+  reasons: string[];
+  primaryReason: string | null;
+}
+
+const WARNING_AGE_SECONDS = 60;
+const CRITICAL_AGE_SECONDS = 180;
+
+const isThrottling = (current?: number, max?: number): boolean => {
+  if (current == null || max == null || max <= 0) {
+    return false;
+  }
+
+  return current < max * 0.85;
+};
+
+export const getNodeTrafficTotal = (node: Node): number => {
+  return (node.network_tx_bytes_per_sec ?? 0) + (node.network_rx_bytes_per_sec ?? 0);
+};
+
+export const getNodeLastSeenAgeSeconds = (
+  node: Node,
+  nowMs: number = Date.now()
+): number | null => {
+  if (node.last_seen_timestamp != null && !Number.isNaN(node.last_seen_timestamp)) {
+    return Math.max(0, Math.floor(nowMs / 1000) - node.last_seen_timestamp);
+  }
+
+  if (!node.last_seen) {
+    return null;
+  }
+
+  const numeric = Number(node.last_seen);
+  if (!Number.isNaN(numeric)) {
+    return Math.max(0, Math.floor(nowMs / 1000) - numeric);
+  }
+
+  const parsed = Date.parse(node.last_seen);
+  if (!Number.isNaN(parsed)) {
+    return Math.max(0, Math.floor((nowMs - parsed) / 1000));
+  }
+
+  return null;
+};
+
+export const getNodeInsight = (
+  node: Node,
+  nowMs: number = Date.now()
+): NodeInsight => {
+  const reasons: string[] = [];
+  let severity = 0;
+  const lastSeenAgeSeconds = getNodeLastSeenAgeSeconds(node, nowMs);
+  const tempCritical = node.temp_critical ?? 85;
+
+  if (node.status === 'offline') {
+    severity += 120;
+    reasons.push('Offline');
+  } else if (node.status === 'warning') {
+    severity += 70;
+    reasons.push('Warning status');
+  }
+
+  if (lastSeenAgeSeconds != null && lastSeenAgeSeconds >= CRITICAL_AGE_SECONDS) {
+    severity += 55;
+    reasons.push(`Heartbeat stale (${Math.floor(lastSeenAgeSeconds / 60)}m)`);
+  } else if (lastSeenAgeSeconds != null && lastSeenAgeSeconds >= WARNING_AGE_SECONDS) {
+    severity += 25;
+    reasons.push(`Heartbeat drifting (${lastSeenAgeSeconds}s)`);
+  }
+
+  if ((node.cpu_percent ?? 0) >= 85) {
+    severity += 24;
+    reasons.push(`CPU ${node.cpu_percent?.toFixed(0)}%`);
+  }
+
+  if ((node.memory_percent ?? 0) >= 85) {
+    severity += 22;
+    reasons.push(`Memory ${node.memory_percent?.toFixed(0)}%`);
+  }
+
+  if ((node.disk_percent ?? 0) >= 90) {
+    severity += 20;
+    reasons.push(`Disk ${node.disk_percent?.toFixed(0)}%`);
+  }
+
+  if ((node.swap_percent ?? 0) >= 50) {
+    severity += 18;
+    reasons.push(`Swap ${node.swap_percent?.toFixed(0)}%`);
+  }
+
+  if (node.cpu_temp_celsius != null && node.cpu_temp_celsius >= tempCritical * 0.9) {
+    severity += 16;
+    reasons.push(`CPU hot at ${node.cpu_temp_celsius.toFixed(0)}C`);
+  }
+
+  if (isThrottling(node.cpu_freq_mhz, node.cpu_freq_max_mhz)) {
+    severity += 12;
+    reasons.push('Frequency throttled');
+  }
+
+  if ((node.network_errin ?? 0) > 0 || (node.network_errout ?? 0) > 0 || (node.network_dropin ?? 0) > 0 || (node.network_dropout ?? 0) > 0) {
+    severity += 10;
+    reasons.push('Network errors reported');
+  }
+
+  return {
+    node,
+    severity,
+    reasons,
+    primaryReason: reasons[0] ?? null,
+  };
+};
+
+export const getAttentionNodes = (
+  nodes: Node[],
+  maxItems: number = nodes.length,
+  nowMs: number = Date.now()
+): NodeInsight[] => {
+  return nodes
+    .map((node) => getNodeInsight(node, nowMs))
+    .filter((insight) => insight.severity > 0)
+    .sort((left, right) => {
+      if (right.severity !== left.severity) {
+        return right.severity - left.severity;
+      }
+
+      return getNodeTrafficTotal(right.node) - getNodeTrafficTotal(left.node);
+    })
+    .slice(0, maxItems);
+};

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Deploy homelab-map manifests to a Kubernetes cluster.
+#
+# This repo focuses on building images; Kubernetes manifests may live in a separate repo.
+# By default, this script deploys from ./k8s if it exists, otherwise it requires a
+# manifests directory via env var.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+MANIFESTS_DIR="${HOMELAB_MAP_MANIFESTS_DIR:-}"
+if [[ -z "${MANIFESTS_DIR}" ]]; then
+  if [[ -d "$PROJECT_ROOT/k8s" ]]; then
+    MANIFESTS_DIR="$PROJECT_ROOT/k8s"
+  fi
+fi
+
+echo "🚀 Deploying homelab-map..."
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "❌ Error: kubectl is required for deployment"
+  exit 1
+fi
+
+if [[ -z "${MANIFESTS_DIR}" ]]; then
+  echo "❌ Error: No manifests directory found."
+  echo ""
+  echo "This repo does not currently include a ./k8s directory."
+  echo "Set HOMELAB_MAP_MANIFESTS_DIR to a folder containing your homelab-map YAML manifests."
+  echo ""
+  echo "Example:"
+  echo "  export HOMELAB_MAP_MANIFESTS_DIR=/path/to/your/manifests"
+  echo "  make deploy"
+  exit 1
+fi
+
+if [[ ! -d "${MANIFESTS_DIR}" ]]; then
+  echo "❌ Error: HOMELAB_MAP_MANIFESTS_DIR does not exist: ${MANIFESTS_DIR}"
+  exit 1
+fi
+
+echo "Manifests: ${MANIFESTS_DIR}"
+echo ""
+
+kubectl apply -f "${MANIFESTS_DIR}"
+
+echo ""
+echo "✅ Deploy applied"
+


### PR DESCRIPTION
## What changed

- rebuilt the app shell into a more deliberate operations cockpit with a stronger header and live status cards
- added a shared cluster insights utility to rank node attention based on stale heartbeats, warning or offline state, resource pressure, throttling, and network errors
- upgraded the stats sidebar with an attention queue, node search, severity-based ordering, and clearer per-node metadata
- refreshed the visual system with a slate and cyan palette and a less generic font stack

## Why

The existing frontend had solid telemetry data, but the framing felt generic and the sidebar was not helping operators find the nodes that actually needed attention. This pass makes the dashboard more readable and more actionable without changing polling or map interaction behavior.

## Impact

- operators get an at-a-glance summary of cluster availability, traffic, latency, and active attention items
- risky or degraded nodes surface automatically at the top of the sidebar
- searching and scanning the node list is faster, especially on larger clusters

## Validation

- `npm run type-check`
- `npm test -- --watchAll=false`
- `npm run build`
