### PR TITLE
[codex] Restore fixed app height for map viewport

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,8 +1,10 @@
 .App {
+  height: 100vh;
   min-height: 100vh;
   width: 100vw;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .dark-mode {


### PR DESCRIPTION
## What changed

- restores a fixed `100vh` root app height on the frontend shell
- keeps `min-height: 100vh` and adds `overflow: hidden` so the viewport contract stays explicit

## Why

`main` already contains the cockpit UI refresh from PR #122, but the follow-up viewport fix was not part of that merge. Without an explicit root height, the DeckGL/MapLibre area can collapse and the map pane renders as a blank surface.

## Impact

- the map viewport renders again on the deployed site
- the PR stays narrowly scoped to the regression fix on top of the already-merged UI refresh

## Validation

- `npm run type-check`
- `npm run build`
